### PR TITLE
Add new deploy scripts.

### DIFF
--- a/script/Deploy7579Controller.s.sol
+++ b/script/Deploy7579Controller.s.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {EmailRecoverySubjectHandler} from "src/handlers/EmailRecoverySubjectHandler.sol";
+import {EmailRecoveryManager} from "src/EmailRecoveryManager.sol";
+import {EmailRecoveryModule} from "src/modules/EmailRecoveryModule.sol";
+import {Verifier} from "ether-email-auth/packages/contracts/src/utils/Verifier.sol";
+import {ECDSAOwnedDKIMRegistry} from "ether-email-auth/packages/contracts/src/utils/ECDSAOwnedDKIMRegistry.sol";
+import {EmailAuth} from "ether-email-auth/packages/contracts/src/EmailAuth.sol";
+import {EmailRecoveryFactory} from "src/EmailRecoveryFactory.sol";
+
+contract Deploy7579ControllerScript is Script {
+    function run() public {
+        vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
+        address verifier = vm.envOr("VERIFIER", address(0));
+        address dkimRegistry = vm.envOr("DKIM_REGISTRY", address(0));
+        address dkimRegistrySigner = vm.envOr("SIGNER", address(0));
+        address emailAuthImpl = vm.envOr("EMAIL_AUTH_IMPL", address(0));
+
+        if (verifier == address(0)) {
+            verifier = address(new Verifier());
+            vm.setEnv("VERIFIER", vm.toString(verifier));
+            console.log("Deployed Verifier at", verifier);
+        }
+
+        if (dkimRegistry == address(0)) {
+            require(
+                dkimRegistrySigner != address(0),
+                "DKIM_REGISTRY_SIGNER is required"
+            );
+            dkimRegistry = address(
+                new ECDSAOwnedDKIMRegistry(dkimRegistrySigner)
+            );
+            vm.setEnv("DKIM_REGISTRY", vm.toString(dkimRegistry));
+            console.log("Deployed DKIM Registry at", dkimRegistry);
+        }
+
+        if (emailAuthImpl == address(0)) {
+            emailAuthImpl = address(new EmailAuth());
+            vm.setEnv("EMAIL_AUTH_IMPL", vm.toString(emailAuthImpl));
+            console.log("Deployed Email Auth at", emailAuthImpl);
+        }
+
+        EmailRecoverySubjectHandler emailRecoveryHandler = new EmailRecoverySubjectHandler();
+        vm.setEnv(
+            "RECOVERY_HANDLER",
+            vm.toString(address(emailRecoveryHandler))
+        );
+        address _factory = vm.envOr("FACTORY", address(0));
+        if (_factory == address(0)) {
+            _factory = address(new EmailRecoveryFactory());
+            vm.setEnv("FACTORY", vm.toString(_factory));
+            console.log("Deployed Email Recovery Factory at", _factory);
+        }
+        EmailRecoveryFactory factory = EmailRecoveryFactory(_factory);
+        (address manager, address module) = factory.deployModuleAndManager(
+            verifier,
+            dkimRegistry,
+            emailAuthImpl,
+            address(emailRecoveryHandler)
+        );
+        vm.setEnv("RECOVERY_MANAGER", vm.toString(manager));
+        vm.setEnv("RECOVERY_MODULE", vm.toString(module));
+
+        console.log(
+            "Deployed Email Recovery Handler at",
+            address(emailRecoveryHandler)
+        );
+        console.log("Deployed Email Recovery Manager at", vm.toString(manager));
+        console.log("Deployed Email Recovery Module at", vm.toString(module));
+        vm.stopBroadcast();
+    }
+}

--- a/script/Deploy7579TestAccount.s.sol
+++ b/script/Deploy7579TestAccount.s.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {EmailRecoverySubjectHandler} from "src/handlers/EmailRecoverySubjectHandler.sol";
+import {EmailRecoveryManager} from "src/EmailRecoveryManager.sol";
+import {EmailRecoveryModule} from "src/modules/EmailRecoveryModule.sol";
+import {Verifier} from "ether-email-auth/packages/contracts/src/utils/Verifier.sol";
+import {ECDSAOwnedDKIMRegistry} from "ether-email-auth/packages/contracts/src/utils/ECDSAOwnedDKIMRegistry.sol";
+import {EmailAuth} from "ether-email-auth/packages/contracts/src/EmailAuth.sol";
+import {EmailRecoveryFactory} from "src/EmailRecoveryFactory.sol";
+import {RhinestoneModuleKit, AccountInstance} from "modulekit/ModuleKit.sol";
+import {OwnableValidator} from "src/test/OwnableValidator.sol";
+import {SubjectUtils} from "ether-email-auth/packages/contracts/src/libraries/SubjectUtils.sol";
+import {MODULE_TYPE_EXECUTOR, MODULE_TYPE_VALIDATOR} from "modulekit/external/ERC7579.sol";
+import {ModuleKitHelpers, ModuleKitUserOp} from "modulekit/ModuleKit.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+contract Deploy7579TestAccountScript is RhinestoneModuleKit, Script {
+    using ModuleKitHelpers for *;
+    using ModuleKitUserOp for *;
+    using Strings for uint256;
+    using Strings for address;
+
+    function run() public {
+        uint256 privKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(privKey);
+        address deployer = vm.addr(privKey);
+
+        AccountInstance memory instance = makeAccountInstance(
+            vm.envBytes32("ACCOUNT_SALT")
+        );
+
+        address validatorAddress = vm.envOr("VALIDATOR", address(0));
+        if (validatorAddress == address(0)) {
+            validatorAddress = address(new OwnableValidator());
+            vm.setEnv("VALIDATOR", vm.toString(validatorAddress));
+            console.log("Deployed Ownable Validator at", validatorAddress);
+        }
+        OwnableValidator validator = OwnableValidator(validatorAddress);
+        instance.installModule({
+            moduleTypeId: MODULE_TYPE_VALIDATOR,
+            module: validatorAddress,
+            data: abi.encode(
+                vm.envOr("OWNER", deployer),
+                vm.envAddress("RECOVERY_MODULE")
+            )
+        });
+
+        bytes4 functionSelector = bytes4(
+            keccak256(bytes("changeOwner(address,address,address)"))
+        );
+        address[] memory guardians = new address[](0);
+        uint256[] memory guardianWeights = new uint256[](0);
+        bytes memory recoveryModuleInstallData = abi.encode(
+            validatorAddress,
+            bytes("0"),
+            functionSelector,
+            new address[](0),
+            new uint256[](0),
+            0,
+            1 seconds,
+            2 weeks
+        );
+        instance.installModule({
+            moduleTypeId: MODULE_TYPE_EXECUTOR,
+            module: vm.envAddress("RECOVERY_MODULE"),
+            data: recoveryModuleInstallData
+        });
+        vm.stopBroadcast();
+    }
+}

--- a/script/Deploy7579TestAccount.s.sol
+++ b/script/Deploy7579TestAccount.s.sol
@@ -51,15 +51,18 @@ contract Deploy7579TestAccountScript is RhinestoneModuleKit, Script {
         bytes4 functionSelector = bytes4(
             keccak256(bytes("changeOwner(address,address,address)"))
         );
-        address[] memory guardians = new address[](0);
-        uint256[] memory guardianWeights = new uint256[](0);
+        address[] memory guardians = new address[](1);
+        guardians[0] = vm.envAddress("GUARDIAN0");
+        uint256[] memory guardianWeights = new uint256[](1);
+        guardianWeights[0] = 1;
+        uint threshold = 1;
         bytes memory recoveryModuleInstallData = abi.encode(
             validatorAddress,
             bytes("0"),
             functionSelector,
-            new address[](0),
-            new uint256[](0),
-            0,
+            guardians,
+            guardianWeights,
+            threshold,
             1 seconds,
             2 weeks
         );


### PR DESCRIPTION
I added `Deploy7579Controller.s.sol` and `Deploy7579TestAccount.s.sol`.
The former and the latter, respectively, deploys `EmailRecoveryFactory`/`EmailRecoverySubjectHandler`/`EmailRecoveryManager`/`EmailRecoveryModule` and `AccountInstance`/`OwnableValidator`.
(The latter also have the account install modules.)