### PR TITLE
Revert if recovery hash differs in processRecovery

### DIFF
--- a/test/integration/OwnableValidatorRecovery/UniversalEmailRecoveryModule/UniversalEmailRecoveryModule.t.sol
+++ b/test/integration/OwnableValidatorRecovery/UniversalEmailRecoveryModule/UniversalEmailRecoveryModule.t.sol
@@ -305,23 +305,18 @@ contract OwnableValidatorRecovery_UniversalEmailRecoveryModule_Integration_Test 
         // process recovery for validator 1
         handleRecovery(accountAddress1, guardians1[0], recoveryDataHash1);
         vm.warp(block.timestamp + 12 seconds);
-        // process recovery for validator 2
-        handleRecovery(accountAddress1, guardians1[0], validator2RecoveryDataHash);
 
-        // process recovery for validator 1
-        handleRecovery(accountAddress1, guardians1[1], recoveryDataHash1);
-        vm.warp(block.timestamp + 12 seconds);
-        // process recovery for validator 2
-        handleRecovery(accountAddress1, guardians1[1], validator2RecoveryDataHash);
+        EmailAuthMsg memory emailAuthMsg =
+            getRecoveryEmailAuthMessage(accountAddress1, guardians1[0], validator2RecoveryDataHash);
 
-        vm.warp(block.timestamp + delay);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IEmailRecoveryManager.InvalidRecoveryDataHash.selector,
-                recoveryDataHash1,
-                validator2RecoveryDataHash
+                validator2RecoveryDataHash,
+                recoveryDataHash1
             )
         );
-        emailRecoveryModule.completeRecovery(accountAddress1, recoveryData1);
+        // process recovery for validator 2
+        emailRecoveryModule.handleRecovery(emailAuthMsg, templateIdx);
     }
 }

--- a/test/unit/EmailRecoveryManager/cancelRecovery.t.sol
+++ b/test/unit/EmailRecoveryManager/cancelRecovery.t.sol
@@ -32,7 +32,7 @@ contract EmailRecoveryManager_cancelRecovery_Test is UnitBase {
         assertEq(recoveryRequest.executeAfter, 0);
         assertEq(recoveryRequest.executeBefore, 0);
         assertEq(recoveryRequest.currentWeight, 1);
-        assertEq(recoveryRequest.recoveryDataHash, "");
+        assertEq(recoveryRequest.recoveryDataHash, recoveryDataHash);
 
         vm.startPrank(otherAddress);
         vm.expectRevert(IEmailRecoveryManager.NoRecoveryInProcess.selector);
@@ -50,7 +50,7 @@ contract EmailRecoveryManager_cancelRecovery_Test is UnitBase {
         assertEq(recoveryRequest.executeAfter, 0);
         assertEq(recoveryRequest.executeBefore, 0);
         assertEq(recoveryRequest.currentWeight, 1);
-        assertEq(recoveryRequest.recoveryDataHash, "");
+        assertEq(recoveryRequest.recoveryDataHash, recoveryDataHash);
 
         vm.startPrank(accountAddress);
         emailRecoveryModule.cancelRecovery();

--- a/test/unit/EmailRecoveryManager/getRecoveryRequest.t.sol
+++ b/test/unit/EmailRecoveryManager/getRecoveryRequest.t.sol
@@ -22,6 +22,6 @@ contract EmailRecoveryManager_getRecoveryRequest_Test is UnitBase {
         assertEq(recoveryRequest.executeAfter, 0);
         assertEq(recoveryRequest.executeBefore, 0);
         assertEq(recoveryRequest.currentWeight, 1);
-        assertEq(recoveryRequest.recoveryDataHash, "");
+        assertEq(recoveryRequest.recoveryDataHash, recoveryDataHash);
     }
 }

--- a/test/unit/EmailRecoveryManager/processRecovery.t.sol
+++ b/test/unit/EmailRecoveryManager/processRecovery.t.sol
@@ -115,7 +115,8 @@ contract EmailRecoveryManager_processRecovery_Test is UnitBase {
 
     function test_ProcessRecovery_RevertWhen_InvalidRecoveryDataHash() public {
         bytes32 invalidRecoveryDataHash = keccak256(abi.encode("invalid hash"));
-        string memory invalidRecoveryDataHashString = uint256(invalidRecoveryDataHash).toHexString(32);
+        string memory invalidRecoveryDataHashString =
+            uint256(invalidRecoveryDataHash).toHexString(32);
 
         acceptGuardian(accountSalt1);
         acceptGuardian(accountSalt2);


### PR DESCRIPTION
Fixes bug when trying to recover multiple validators at once. This is done by reverting if the recovery data hash is different from the one stored. If recovering a different validator, the recovery hash will change.

Recovery for multiple validators can still be setup in the module. This change means that only a single recovery request for a single validator can be processed at a time in the manager.