### PR TITLE
chore: Remove prepare-artifacts.sh it doesn't exist anymore.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gas:snapshot:optimized": "pnpm run build:optimized && FOUNDRY_PROFILE=test-optimized forge snapshot --mp \"./test/integration/**/*.sol\" --nmt \"test(Fork)?(Fuzz)?_RevertWhen_\\w{1,}?\"",
     "lint": "pnpm run lint:sol && bun run prettier:check",
     "lint:sol": "forge fmt --check && pnpm solhint \"{script,src,test}/**/*.sol\"",
-    "prepack": "pnpm install && bash ./shell/prepare-artifacts.sh",
+    "prepack": "pnpm install",
     "prettier:check": "prettier --check \"**/*.{json,md,svg,yml}\"",
     "prettier:write": "prettier --write \"**/*.{json,md,svg,yml}\"",
     "test": "forge test",


### PR DESCRIPTION
This PR doesn't change contract files.
When I fetch this repo from github in package.json with pnpm, pnpm try to retrieve the git-hosted package from https://codeload.github.com.
But ./shell/prepare-artifacts.s doesn't exist anymore. 

This PR fixes this issue.

```
Failed to prepare git-hosted package fetched from "https://codeload.github.com/zkemail/email-recovery/tar.gz/85d3ff94677da3e9206d63815edcf8604a422245": email-recovery@0.0.1 prepack: `pnpm install && bash ./shell/prepare-artifacts.sh
```


