### PR TITLE
Feat/fix test allow validator recovery

### DIFF
--- a/test/unit/modules/UniversalEmailRecoveryModule/allowValidatorRecovery.t.sol
+++ b/test/unit/modules/UniversalEmailRecoveryModule/allowValidatorRecovery.t.sol
@@ -33,7 +33,7 @@ contract UniversalEmailRecoveryModule_allowValidatorRecovery_Test is UnitBase {
         _skipIfNotSafeAccountType();
         vm.startPrank(accountAddress);
         emailRecoveryModule.allowValidatorRecovery(
-            validatorAddress, bytes("0"), ISafe.addOwnerWithThreshold.selector
+            accountAddress, bytes("0"), ISafe.addOwnerWithThreshold.selector
         );
     }
 
@@ -41,7 +41,7 @@ contract UniversalEmailRecoveryModule_allowValidatorRecovery_Test is UnitBase {
         _skipIfNotSafeAccountType();
         vm.startPrank(accountAddress);
         emailRecoveryModule.allowValidatorRecovery(
-            validatorAddress, bytes("0"), ISafe.removeOwner.selector
+            accountAddress, bytes("0"), ISafe.removeOwner.selector
         );
     }
 
@@ -49,7 +49,7 @@ contract UniversalEmailRecoveryModule_allowValidatorRecovery_Test is UnitBase {
         _skipIfNotSafeAccountType();
         vm.startPrank(accountAddress);
         emailRecoveryModule.allowValidatorRecovery(
-            validatorAddress, bytes("0"), ISafe.swapOwner.selector
+            accountAddress, bytes("0"), ISafe.swapOwner.selector
         );
     }
 
@@ -57,7 +57,7 @@ contract UniversalEmailRecoveryModule_allowValidatorRecovery_Test is UnitBase {
         _skipIfNotSafeAccountType();
         vm.startPrank(accountAddress);
         emailRecoveryModule.allowValidatorRecovery(
-            validatorAddress, bytes("0"), ISafe.changeThreshold.selector
+            accountAddress, bytes("0"), ISafe.changeThreshold.selector
         );
     }
 

--- a/test/unit/modules/UniversalEmailRecoveryModule/allowValidatorRecovery.t.sol
+++ b/test/unit/modules/UniversalEmailRecoveryModule/allowValidatorRecovery.t.sol
@@ -16,8 +16,13 @@ import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 contract UniversalEmailRecoveryModule_allowValidatorRecovery_Test is UnitBase {
     using ModuleKitHelpers for *;
 
+    address validator2Address;
+
     function setUp() public override {
         super.setUp();
+        // Deploy new validator, it's not installed via installModule function. 
+        OwnableValidator validator2 = new OwnableValidator();
+        validator2Address = address(validator2);
     }
 
     function test_AllowValidatorRecovery_RevertWhen_RecoveryModuleNotInitialized() public {
@@ -32,32 +37,52 @@ contract UniversalEmailRecoveryModule_allowValidatorRecovery_Test is UnitBase {
     function test_AllowValidatorRecovery_When_SafeAddOwnerSelector() public {
         _skipIfNotSafeAccountType();
         vm.startPrank(accountAddress);
+        vm.mockCall(
+            address(accountAddress),
+            abi.encodeWithSelector(IERC7579Account.isModuleInstalled.selector),
+            abi.encode(true)
+        );
         emailRecoveryModule.allowValidatorRecovery(
-            accountAddress, bytes("0"), ISafe.addOwnerWithThreshold.selector
+            validator2Address, bytes("0"), ISafe.addOwnerWithThreshold.selector
         );
     }
 
     function test_AllowValidatorRecovery_When_SafeRemoveOwnerSelector() public {
         _skipIfNotSafeAccountType();
         vm.startPrank(accountAddress);
+        vm.mockCall(
+            address(accountAddress),
+            abi.encodeWithSelector(IERC7579Account.isModuleInstalled.selector),
+            abi.encode(true)
+        );
         emailRecoveryModule.allowValidatorRecovery(
-            accountAddress, bytes("0"), ISafe.removeOwner.selector
+            validator2Address, bytes("0"), ISafe.removeOwner.selector
         );
     }
 
     function test_AllowValidatorRecovery_When_SafeSwapOwnerSelector() public {
         _skipIfNotSafeAccountType();
         vm.startPrank(accountAddress);
+        vm.mockCall(
+            address(accountAddress),
+            abi.encodeWithSelector(IERC7579Account.isModuleInstalled.selector),
+            abi.encode(true)
+        );
         emailRecoveryModule.allowValidatorRecovery(
-            accountAddress, bytes("0"), ISafe.swapOwner.selector
+            validator2Address, bytes("0"), ISafe.swapOwner.selector
         );
     }
 
     function test_AllowValidatorRecovery_When_SafeChangeThresholdSelector() public {
         _skipIfNotSafeAccountType();
         vm.startPrank(accountAddress);
+        vm.mockCall(
+            address(accountAddress),
+            abi.encodeWithSelector(IERC7579Account.isModuleInstalled.selector),
+            abi.encode(true)
+        );
         emailRecoveryModule.allowValidatorRecovery(
-            accountAddress, bytes("0"), ISafe.changeThreshold.selector
+            validator2Address, bytes("0"), ISafe.changeThreshold.selector
         );
     }
 


### PR DESCRIPTION
For testing allowValidatorRecovery, 
I created the validator2Address variable, it's not installed via isModuleInstalled. 
allowValidatorRecovery needs to be installed of validator to succeed, but if the module installed function called, the validator already been registered. 
I added the mockCall for isModuleInstalled function.