### PR TITLE
Remove email-wallet-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@rhinestone/modulekit": "github:rhinestonewtf/modulekit",
     "@zk-email/contracts": "6.0.3",
     "@zk-email/ether-email-auth-contracts": "0.0.2-preview",
-    "email-wallet-sdk": "github:zkemail/email-wallet-sdk",
     "erc7579-implementation": "github:erc7579/erc7579-implementation",
     "solidity-stringutils": "github:LayerZero-Labs/solidity-stringutils"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zk-email/email-recovery",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Smart account module and related contracts to enable email recovery for validators",
   "license": "MIT",
   "author": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@zk-email/ether-email-auth-contracts':
         specifier: 0.0.2-preview
         version: 0.0.2-preview
-      email-wallet-sdk:
-        specifier: github:zkemail/email-wallet-sdk
-        version: https://codeload.github.com/zkemail/email-wallet-sdk/tar.gz/a8c200e4855a81adc7b9493afa92a898ffcb8c56(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       erc7579-implementation:
         specifier: github:erc7579/erc7579-implementation
         version: https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
@@ -46,10 +43,6 @@ packages:
   '@babel/highlight@7.24.7':
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
-
-  '@email-wallet/contracts@https://gitpkg.now.sh/zkemail/email-wallet/packages/contracts?8ae807dfcfe617a1a3e4b5342a667f0f595b8c82':
-    resolution: {tarball: https://gitpkg.now.sh/zkemail/email-wallet/packages/contracts?8ae807dfcfe617a1a3e4b5342a667f0f595b8c82}
-    version: 1.0.0
 
   '@ethereumjs/rlp@4.0.1':
     resolution: {integrity: sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==}
@@ -298,16 +291,10 @@ packages:
     peerDependencies:
       hardhat: ^2.0.4
 
-  '@openzeppelin/contracts-upgradeable@4.9.6':
-    resolution: {integrity: sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==}
-
   '@openzeppelin/contracts-upgradeable@5.0.1':
     resolution: {integrity: sha512-MvaLoPnVcoZr/qqZP+4cl9piuR4gg0iIGgxVSZ/AL1iId3M6IdEHzz9Naw5Lirl4KKBI6ciTVnX07yL4dOMIJg==}
     peerDependencies:
       '@openzeppelin/contracts': 5.0.1
-
-  '@openzeppelin/contracts@3.4.2-solc-0.7':
-    resolution: {integrity: sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA==}
 
   '@openzeppelin/contracts@4.9.6':
     resolution: {integrity: sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==}
@@ -477,31 +464,6 @@ packages:
   '@types/secp256k1@4.0.6':
     resolution: {integrity: sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==}
 
-  '@uniswap/lib@4.0.1-alpha':
-    resolution: {integrity: sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==}
-    engines: {node: '>=10'}
-
-  '@uniswap/v2-core@1.0.1':
-    resolution: {integrity: sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q==}
-    engines: {node: '>=10'}
-
-  '@uniswap/v3-core@1.0.1':
-    resolution: {integrity: sha512-7pVk4hEm00j9tc71Y9+ssYpO6ytkeI0y7WE9P6UcmNzhxPePwyAxImuhVsTqWK9YFvzgtvzJHi64pBl4jUzKMQ==}
-    engines: {node: '>=10'}
-
-  '@uniswap/v3-core@https://codeload.github.com/Uniswap/v3-core/tar.gz/6562c52e8f75f0c10f9deaf44861847585fc8129':
-    resolution: {tarball: https://codeload.github.com/Uniswap/v3-core/tar.gz/6562c52e8f75f0c10f9deaf44861847585fc8129}
-    version: 1.0.1-solc-0.8
-    engines: {node: '>=10'}
-
-  '@uniswap/v3-periphery@https://codeload.github.com/Uniswap/v3-periphery/tar.gz/0682387198a24c7cd63566a2c58398533860a5d1':
-    resolution: {tarball: https://codeload.github.com/Uniswap/v3-periphery/tar.gz/0682387198a24c7cd63566a2c58398533860a5d1}
-    version: 1.4.4
-    engines: {node: '>=10'}
-
-  '@zk-email/contracts@4.1.0':
-    resolution: {integrity: sha512-5cFgx1kpAPL0Pl5wUb2SA3qaIgYpbp5jjonuYH268BaspvyqSoFS77/UVX+4yjbOQtZmrTntaYXNaseghLLlXw==}
-
   '@zk-email/contracts@6.0.3':
     resolution: {integrity: sha512-nPSG27431Cz5bzPlR/ltn7qa9k+Joc/6LDHUz+JeFWEP/ff9VnzK11P0ay5qdX14qpQ647varPdxGtulosUtxw==}
 
@@ -628,9 +590,6 @@ packages:
 
   base-x@3.0.10:
     resolution: {integrity: sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==}
-
-  base64-sol@1.0.1:
-    resolution: {integrity: sha512-ld3cCNMeXt4uJXmLZBHFGMvVpK9KsLVEhPpFRXnvSVAqABKbuNZg/+dsq3NuM+wxFLb/UrVkz7m1ciWmkMfTbg==}
 
   bech32@1.1.4:
     resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
@@ -871,10 +830,6 @@ packages:
   elliptic@6.5.7:
     resolution: {integrity: sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==}
 
-  email-wallet-sdk@https://codeload.github.com/zkemail/email-wallet-sdk/tar.gz/a8c200e4855a81adc7b9493afa92a898ffcb8c56:
-    resolution: {tarball: https://codeload.github.com/zkemail/email-wallet-sdk/tar.gz/a8c200e4855a81adc7b9493afa92a898ffcb8c56}
-    version: 0.0.1
-
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1036,13 +991,13 @@ packages:
       debug:
         optional: true
 
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/5a802d7c10abb4bbfb3e7214c75052ef9e6a06f8:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/5a802d7c10abb4bbfb3e7214c75052ef9e6a06f8}
+    version: 1.9.2
+
   forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/ae570fec082bfe1c1f45b0acca4a2b4f84d345ce:
     resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/ae570fec082bfe1c1f45b0acca4a2b4f84d345ce}
     version: 1.7.6
-
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/e04104ab93e771441eab03fb76eda1402cb5927b:
-    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/e04104ab93e771441eab03fb76eda1402cb5927b}
-    version: 1.9.2
 
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
@@ -1787,9 +1742,9 @@ packages:
   solady@0.0.123:
     resolution: {integrity: sha512-F/B8OMCplGsS4FrdPrnEG0xdg8HKede5PwC+Rum8soj/LWxfKckA0p+Uwnlbgey2iI82IHvmSOCNhsdbA+lUrw==}
 
-  solady@https://codeload.github.com/vectorized/solady/tar.gz/4f50982008973b1431768a75fb88ac8eca21b9f6:
-    resolution: {tarball: https://codeload.github.com/vectorized/solady/tar.gz/4f50982008973b1431768a75fb88ac8eca21b9f6}
-    version: 0.0.238
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/362b2efd20f38aea7252b391e5e016633ff79641:
+    resolution: {tarball: https://codeload.github.com/vectorized/solady/tar.gz/362b2efd20f38aea7252b391e5e016633ff79641}
+    version: 0.0.243
 
   solady@https://codeload.github.com/vectorized/solady/tar.gz/9deb9ed36a27261a8745db5b7cd7f4cdc3b1cd4e:
     resolution: {tarball: https://codeload.github.com/vectorized/solady/tar.gz/9deb9ed36a27261a8745db5b7cd7f4cdc3b1cd4e}
@@ -1813,10 +1768,6 @@ packages:
     hasBin: true
     peerDependencies:
       hardhat: ^2.11.0
-
-  solidity-stringutils.git@https://codeload.github.com/Arachnid/solidity-stringutils/tar.gz/4b2fcc43fa0426e19ce88b1f1ec16f5903a2e461:
-    resolution: {tarball: https://codeload.github.com/Arachnid/solidity-stringutils/tar.gz/4b2fcc43fa0426e19ce88b1f1ec16f5903a2e461}
-    version: 0.0.0
 
   solidity-stringutils@https://codeload.github.com/LayerZero-Labs/solidity-stringutils/tar.gz/eb21d6b502c2741145ab2a90f5f5b4fda9dfb218:
     resolution: {tarball: https://codeload.github.com/LayerZero-Labs/solidity-stringutils/tar.gz/eb21d6b502c2741145ab2a90f5f5b4fda9dfb218}
@@ -2097,25 +2048,6 @@ snapshots:
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.1.0
-
-  '@email-wallet/contracts@https://gitpkg.now.sh/zkemail/email-wallet/packages/contracts?8ae807dfcfe617a1a3e4b5342a667f0f595b8c82(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))':
-    dependencies:
-      '@openzeppelin/contracts': 4.9.6
-      '@openzeppelin/contracts-upgradeable': 4.9.6
-      '@uniswap/v3-core': https://codeload.github.com/Uniswap/v3-core/tar.gz/6562c52e8f75f0c10f9deaf44861847585fc8129
-      '@uniswap/v3-periphery': https://codeload.github.com/Uniswap/v3-periphery/tar.gz/0682387198a24c7cd63566a2c58398533860a5d1
-      '@zk-email/contracts': 4.1.0
-      accountabstraction: https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      solady: 0.0.123
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - ethers
-      - hardhat
-      - lodash
-      - supports-color
-      - typechain
-      - utf-8-validate
 
   '@ethereumjs/rlp@4.0.1': {}
 
@@ -2514,13 +2446,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@openzeppelin/contracts-upgradeable@4.9.6': {}
-
   '@openzeppelin/contracts-upgradeable@5.0.1(@openzeppelin/contracts@5.0.2)':
     dependencies:
       '@openzeppelin/contracts': 5.0.2
-
-  '@openzeppelin/contracts@3.4.2-solc-0.7': {}
 
   '@openzeppelin/contracts@4.9.6': {}
 
@@ -2544,8 +2472,8 @@ snapshots:
 
   '@rhinestone/checknsignatures@https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/7ff44ef46da1266374e6a98e6cf69d727d7c357d':
     dependencies:
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/e04104ab93e771441eab03fb76eda1402cb5927b
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/4f50982008973b1431768a75fb88ac8eca21b9f6
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/5a802d7c10abb4bbfb3e7214c75052ef9e6a06f8
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/362b2efd20f38aea7252b391e5e016633ff79641
 
   '@rhinestone/erc4337-validation@0.0.1-alpha.2(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))(typescript@4.9.5)':
     dependencies:
@@ -2553,9 +2481,9 @@ snapshots:
       account-abstraction: accountabstraction@https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       account-abstraction-v0.6: accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/e04104ab93e771441eab03fb76eda1402cb5927b
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/5a802d7c10abb4bbfb3e7214c75052ef9e6a06f8
       prettier: 2.8.8
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/4f50982008973b1431768a75fb88ac8eca21b9f6
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/362b2efd20f38aea7252b391e5e016633ff79641
       solhint: 4.5.4(typescript@4.9.5)
     transitivePeerDependencies:
       - bufferutil
@@ -2574,9 +2502,9 @@ snapshots:
       account-abstraction: accountabstraction@https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       account-abstraction-v0.6: accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/e04104ab93e771441eab03fb76eda1402cb5927b
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/5a802d7c10abb4bbfb3e7214c75052ef9e6a06f8
       prettier: 2.8.8
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/4f50982008973b1431768a75fb88ac8eca21b9f6
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/362b2efd20f38aea7252b391e5e016633ff79641
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2591,7 +2519,7 @@ snapshots:
     dependencies:
       '@ERC4337/account-abstraction': accountabstraction@https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       erc7579: erc7579-implementation@https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/e04104ab93e771441eab03fb76eda1402cb5927b
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/5a802d7c10abb4bbfb3e7214c75052ef9e6a06f8
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2617,8 +2545,8 @@ snapshots:
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
       erc7579: erc7579-implementation@https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       excessively-safe-call: '@nomad-xyz/excessively-safe-call@https://codeload.github.com/nomad-xyz/ExcessivelySafeCall/tar.gz/81cd99ce3e69117d665d7601c330ea03b97acce0'
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/e04104ab93e771441eab03fb76eda1402cb5927b
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/4f50982008973b1431768a75fb88ac8eca21b9f6
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/5a802d7c10abb4bbfb3e7214c75052ef9e6a06f8
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/362b2efd20f38aea7252b391e5e016633ff79641
       solarray: https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684
     transitivePeerDependencies:
       - bufferutil
@@ -2648,8 +2576,8 @@ snapshots:
       '@safe-global/safe-contracts': 1.4.1(ethers@5.7.2)
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
       erc7579: erc7579-implementation@https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/e04104ab93e771441eab03fb76eda1402cb5927b
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/4f50982008973b1431768a75fb88ac8eca21b9f6
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/5a802d7c10abb4bbfb3e7214c75052ef9e6a06f8
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/362b2efd20f38aea7252b391e5e016633ff79641
       solarray: https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684
     transitivePeerDependencies:
       - bufferutil
@@ -2664,7 +2592,7 @@ snapshots:
 
   '@rhinestone/sentinellist@https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/67e42f0eb3cf355ddba5a017892f9cc28d924875':
     dependencies:
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/e04104ab93e771441eab03fb76eda1402cb5927b
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/5a802d7c10abb4bbfb3e7214c75052ef9e6a06f8
 
   '@safe-global/safe-contracts@1.4.1(ethers@5.7.2)':
     dependencies:
@@ -2812,27 +2740,6 @@ snapshots:
   '@types/secp256k1@4.0.6':
     dependencies:
       '@types/node': 22.5.4
-
-  '@uniswap/lib@4.0.1-alpha': {}
-
-  '@uniswap/v2-core@1.0.1': {}
-
-  '@uniswap/v3-core@1.0.1': {}
-
-  '@uniswap/v3-core@https://codeload.github.com/Uniswap/v3-core/tar.gz/6562c52e8f75f0c10f9deaf44861847585fc8129': {}
-
-  '@uniswap/v3-periphery@https://codeload.github.com/Uniswap/v3-periphery/tar.gz/0682387198a24c7cd63566a2c58398533860a5d1':
-    dependencies:
-      '@openzeppelin/contracts': 3.4.2-solc-0.7
-      '@uniswap/lib': 4.0.1-alpha
-      '@uniswap/v2-core': 1.0.1
-      '@uniswap/v3-core': 1.0.1
-      base64-sol: 1.0.1
-
-  '@zk-email/contracts@4.1.0':
-    dependencies:
-      '@openzeppelin/contracts': 4.9.6
-      dotenv: 16.4.5
 
   '@zk-email/contracts@6.0.3':
     dependencies:
@@ -3032,8 +2939,6 @@ snapshots:
   base-x@3.0.10:
     dependencies:
       safe-buffer: 5.2.1
-
-  base64-sol@1.0.1: {}
 
   bech32@1.1.4: {}
 
@@ -3298,26 +3203,6 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
-  email-wallet-sdk@https://codeload.github.com/zkemail/email-wallet-sdk/tar.gz/a8c200e4855a81adc7b9493afa92a898ffcb8c56(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5)):
-    dependencies:
-      '@email-wallet/contracts': https://gitpkg.now.sh/zkemail/email-wallet/packages/contracts?8ae807dfcfe617a1a3e4b5342a667f0f595b8c82(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      '@openzeppelin/contracts': 4.9.6
-      '@openzeppelin/contracts-upgradeable': 4.9.6
-      '@uniswap/v3-core': https://codeload.github.com/Uniswap/v3-core/tar.gz/6562c52e8f75f0c10f9deaf44861847585fc8129
-      '@uniswap/v3-periphery': https://codeload.github.com/Uniswap/v3-periphery/tar.gz/0682387198a24c7cd63566a2c58398533860a5d1
-      '@zk-email/contracts': 4.1.0
-      solady: 0.0.123
-      solidity-stringutils: solidity-stringutils.git@https://codeload.github.com/Arachnid/solidity-stringutils/tar.gz/4b2fcc43fa0426e19ce88b1f1ec16f5903a2e461
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - ethers
-      - hardhat
-      - lodash
-      - supports-color
-      - typechain
-      - utf-8-validate
-
   emoji-regex@8.0.0: {}
 
   encode-utf8@1.0.3: {}
@@ -3336,8 +3221,8 @@ snapshots:
       '@rhinestone/sentinellist': https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/67e42f0eb3cf355ddba5a017892f9cc28d924875
       account-abstraction: accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/6f02f5a28a20e804d0410b4b5b570dd4b076dcf9(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/e04104ab93e771441eab03fb76eda1402cb5927b
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/4f50982008973b1431768a75fb88ac8eca21b9f6
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/5a802d7c10abb4bbfb3e7214c75052ef9e6a06f8
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/362b2efd20f38aea7252b391e5e016633ff79641
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -3552,9 +3437,9 @@ snapshots:
     optionalDependencies:
       debug: 4.3.7(supports-color@8.1.1)
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/ae570fec082bfe1c1f45b0acca4a2b4f84d345ce: {}
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/5a802d7c10abb4bbfb3e7214c75052ef9e6a06f8: {}
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/e04104ab93e771441eab03fb76eda1402cb5927b: {}
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/ae570fec082bfe1c1f45b0acca4a2b4f84d345ce: {}
 
   form-data-encoder@2.1.4: {}
 
@@ -4378,7 +4263,7 @@ snapshots:
 
   solady@0.0.123: {}
 
-  solady@https://codeload.github.com/vectorized/solady/tar.gz/4f50982008973b1431768a75fb88ac8eca21b9f6: {}
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/362b2efd20f38aea7252b391e5e016633ff79641: {}
 
   solady@https://codeload.github.com/vectorized/solady/tar.gz/9deb9ed36a27261a8745db5b7cd7f4cdc3b1cd4e: {}
 
@@ -4443,8 +4328,6 @@ snapshots:
       semver: 7.6.3
       shelljs: 0.8.5
       web3-utils: 1.10.4
-
-  solidity-stringutils.git@https://codeload.github.com/Arachnid/solidity-stringutils/tar.gz/4b2fcc43fa0426e19ce88b1f1ec16f5903a2e461: {}
 
   solidity-stringutils@https://codeload.github.com/LayerZero-Labs/solidity-stringutils/tar.gz/eb21d6b502c2741145ab2a90f5f5b4fda9dfb218: {}
 


### PR DESCRIPTION
As far as I see, email-recovery repo doesn't use email-wallet-sdk everywhere.
I removed email-wallet-sdk it rid the dependency of open zeppelin v4.