### PR TITLE
feat: new ERC7579 recovery module Prototype

### DIFF
--- a/src/simple-recovery-module/SimpleRecoveryModule.sol
+++ b/src/simple-recovery-module/SimpleRecoveryModule.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {
+    IVerifier,
+    EmailProof
+} from "@zk-email/ether-email-auth-contracts/src/interfaces/IVerifier.sol";
+
+interface IERC7579Account {
+    function changeOwner(address newOwner) external;
+}
+
+interface IDKIMRegistry {
+    function isDKIMPublicKeyHashValid(
+        string memory domainName,
+        bytes32 publicKeyHash
+    )
+        external
+        view
+        returns (bool);
+}
+
+/**
+ * @title SimpleRecoveryModule
+ * @notice A simple recovery module that supports both ZK Email & EOA guardians
+ */
+contract SimpleRecoveryModule {
+    // State variables
+    mapping(address => address) public accountOwners;
+    mapping(address => address) public accountGuardians;
+    mapping(address => bytes32) public accountNullifiers;
+
+    IVerifier public immutable zkEmailVerifier;
+    IDKIMRegistry public immutable dkimRegistry;
+
+    // Events
+    event RecoveryInitiated(address indexed account, address newOwner);
+    event GuardianSet(address indexed account, address guardian);
+    event NullifierUsed(bytes32 indexed nullifier, address indexed account);
+    event InvalidProofAttempt(
+        address indexed account, uint256 proofTimestamp, uint256 currentTimestamp, string reason
+    );
+
+    // Errors
+    error SimpleRecoveryModule__InvalidGuardian();
+    error SimpleRecoveryModule__InvalidProof();
+    error SimpleRecoveryModule__InvalidDKIM();
+    error SimpleRecoveryModule__NullifierIsUsed();
+    error SimpleRecoveryModule__InvalidNewOwner();
+    error SimpleRecoveryModule__GuardianAlreadySet();
+
+    constructor(address _verifier, address _dkimRegistry) {
+        require(_verifier != address(0), "Invalid verifier address");
+        require(_dkimRegistry != address(0), "Invalid DKIM registry address");
+        zkEmailVerifier = IVerifier(_verifier);
+        dkimRegistry = IDKIMRegistry(_dkimRegistry);
+    }
+
+    /**
+     * @notice Set up EOA guardian for account
+     * @param guardian EOA guardian address
+     */
+    function setupGuardian(address guardian) external {
+        if (guardian == address(0)) revert SimpleRecoveryModule__InvalidGuardian();
+        if (accountGuardians[msg.sender] != address(0)) {
+            revert SimpleRecoveryModule__GuardianAlreadySet();
+        }
+        accountGuardians[msg.sender] = guardian;
+        accountOwners[msg.sender] = msg.sender;
+
+        emit GuardianSet(msg.sender, guardian);
+    }
+
+    /**
+     * @notice Recover account using an EOA guardian
+     * @param account Account to be recovered
+     * @param newOwner New owner address
+     */
+    function recoverByGuardian(address account, address newOwner) external {
+        if (msg.sender != accountGuardians[account]) revert SimpleRecoveryModule__InvalidGuardian();
+        if (newOwner == address(0)) revert SimpleRecoveryModule__InvalidNewOwner();
+
+        _executeRecovery(account, newOwner);
+    }
+
+    /**
+     * @notice Recover account using ZK Email proof
+     * @param account Account to be recovered
+     * @param newOwner New owner address
+     * @param emailProof Email proof data
+     */
+    function recoverByEmail(
+        address account,
+        address newOwner,
+        EmailProof calldata emailProof
+    )
+        external
+    {
+        if (newOwner == address(0)) revert SimpleRecoveryModule__InvalidNewOwner();
+
+        // Verify DKIM
+        if (!dkimRegistry.isDKIMPublicKeyHashValid(emailProof.domainName, emailProof.publicKeyHash))
+        {
+            revert SimpleRecoveryModule__InvalidDKIM();
+        }
+
+        // Prevent replay attacks by verifying nullifier hasn't been used
+        if (accountNullifiers[account] == emailProof.emailNullifier) {
+            emit InvalidProofAttempt(
+                account, emailProof.timestamp, block.timestamp, "Nullifier already used"
+            );
+            revert SimpleRecoveryModule__NullifierIsUsed();
+        }
+
+        // Verify proof
+        if (!zkEmailVerifier.verifyEmailProof(emailProof)) {
+            revert SimpleRecoveryModule__InvalidProof();
+        }
+
+        // Prevent replay attacks with outdated proofs
+        if (emailProof.timestamp < block.timestamp - 1 hours) {
+            emit InvalidProofAttempt(
+                account, emailProof.timestamp, block.timestamp, "Proof expired"
+            );
+            revert SimpleRecoveryModule__InvalidProof();
+        }
+
+        // Store nullifier
+        accountNullifiers[account] = emailProof.emailNullifier;
+        emit NullifierUsed(emailProof.emailNullifier, account);
+
+        _executeRecovery(account, newOwner);
+    }
+
+    /**
+     * @notice Internal function to execute recovery
+     */
+    function _executeRecovery(address account, address newOwner) internal {
+        IERC7579Account(account).changeOwner(newOwner);
+        accountOwners[account] = newOwner;
+
+        emit RecoveryInitiated(account, newOwner);
+    }
+}

--- a/test/SimpleRecoveryModule.t.sol
+++ b/test/SimpleRecoveryModule.t.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import "../src/simple-recovery-module/SimpleRecoveryModule.sol";
+
+// Mock contracts for the dependencies
+contract MockVerifier is IVerifier {
+    function commandBytes() external pure override returns (uint256) {
+        return 123;
+    }
+
+    function verifyEmailProof(EmailProof calldata) external pure override returns (bool) {
+        return true;
+    }
+}
+
+contract MockDKIMRegistry is IDKIMRegistry {
+    function isDKIMPublicKeyHashValid(
+        string memory,
+        bytes32
+    )
+        external
+        pure
+        override
+        returns (bool)
+    {
+        return true;
+    }
+}
+
+contract MockAccount is IERC7579Account {
+    address public owner;
+
+    function changeOwner(address newOwner) external override {
+        owner = newOwner;
+    }
+}
+
+contract SimpleRecoveryModuleTest is Test {
+    SimpleRecoveryModule module;
+    MockVerifier verifier;
+    MockDKIMRegistry dkimRegistry;
+    MockAccount mockAccount;
+
+    address owner = address(0x1);
+    address guardian = address(0x2);
+    address newOwner = address(0x3);
+    address nonGuardian = address(0x4);
+
+    function setUp() public {
+        verifier = new MockVerifier();
+        dkimRegistry = new MockDKIMRegistry();
+        module = new SimpleRecoveryModule(address(verifier), address(dkimRegistry));
+        mockAccount = new MockAccount();
+        
+        // Initialize timestamp to avoid underflow
+        vm.warp(block.timestamp + 2 hours);
+    }
+
+    function testSetupGuardian() public {
+        vm.prank(owner);
+        module.setupGuardian(guardian);
+        assertEq(module.accountGuardians(owner), guardian, "Guardian should be set correctly");
+        assertEq(module.accountOwners(owner), owner, "Owner should be set correctly");
+    }
+
+    function testCannotSetGuardianTwice() public {
+        vm.prank(owner);
+        module.setupGuardian(guardian);
+
+        vm.prank(owner);
+        vm.expectRevert(SimpleRecoveryModule.SimpleRecoveryModule__GuardianAlreadySet.selector);
+        module.setupGuardian(guardian);
+    }
+
+    function testRecoverByGuardian() public {
+        // Setup the account and guardian first
+        vm.startPrank(address(mockAccount));
+        module.setupGuardian(guardian);
+        vm.stopPrank();
+
+        // Perform recovery by guardian
+        vm.prank(guardian);
+        module.recoverByGuardian(address(mockAccount), newOwner);
+
+        assertEq(mockAccount.owner(), newOwner, "Owner should be updated to newOwner");
+        assertEq(module.accountOwners(address(mockAccount)), newOwner, "Account owner mapping should be updated");
+    }
+
+    function testCannotRecoverByNonGuardian() public {
+        // Setup the account and guardian first
+        vm.startPrank(address(mockAccount));
+        module.setupGuardian(guardian);
+        vm.stopPrank();
+
+        vm.prank(nonGuardian);
+        vm.expectRevert(SimpleRecoveryModule.SimpleRecoveryModule__InvalidGuardian.selector);
+        module.recoverByGuardian(address(mockAccount), newOwner);
+    }
+
+    function testRecoverByEmail() public {
+        uint256 currentTime = block.timestamp;
+        
+        EmailProof memory emailProof = EmailProof({
+            domainName: "example.com",
+            publicKeyHash: keccak256("public_key"),
+            timestamp: currentTime,
+            maskedCommand: "recovery",
+            emailNullifier: keccak256("nullifier"),
+            accountSalt: keccak256("salt"),
+            isCodeExist: true,
+            proof: bytes("dummy_proof")
+        });
+
+        // Perform recovery by email
+        module.recoverByEmail(address(mockAccount), newOwner, emailProof);
+
+        assertEq(mockAccount.owner(), newOwner, "Owner should be updated to newOwner");
+        assertEq(module.accountOwners(address(mockAccount)), newOwner, "Account owner mapping should be updated");
+        assertEq(module.accountNullifiers(address(mockAccount)), emailProof.emailNullifier, "Nullifier should be stored");
+    }
+
+    function testCannotRecoverWithInvalidNullifier() public {
+        uint256 currentTime = block.timestamp;
+        
+        EmailProof memory emailProof = EmailProof({
+            domainName: "example.com",
+            publicKeyHash: keccak256("public_key"),
+            timestamp: currentTime,
+            maskedCommand: "recovery",
+            emailNullifier: keccak256("nullifier"),
+            accountSalt: keccak256("salt"),
+            isCodeExist: true,
+            proof: bytes("dummy_proof")
+        });
+
+        // Perform first recovery
+        module.recoverByEmail(address(mockAccount), newOwner, emailProof);
+
+        // Try to recover again with the same nullifier
+        vm.expectRevert(SimpleRecoveryModule.SimpleRecoveryModule__NullifierIsUsed.selector);
+        module.recoverByEmail(address(mockAccount), newOwner, emailProof);
+    }
+
+    function testCannotRecoverWithExpiredProof() public {
+        // Set a base timestamp
+        uint256 currentTime = block.timestamp;
+        
+        // Create the email proof with an expired timestamp
+        EmailProof memory emailProof = EmailProof({
+            domainName: "example.com",
+            publicKeyHash: keccak256("public_key"),
+            timestamp: currentTime - 2 hours,  // 2 hours old, which exceeds the 1 hour limit
+            maskedCommand: "recovery",
+            emailNullifier: keccak256("nullifier"),
+            accountSalt: keccak256("salt"),
+            isCodeExist: true,
+            proof: bytes("dummy_proof")
+        });
+
+        vm.expectRevert(SimpleRecoveryModule.SimpleRecoveryModule__InvalidProof.selector);
+        module.recoverByEmail(address(mockAccount), newOwner, emailProof);
+    }
+}


### PR DESCRIPTION
Implement SimpleRecoveryModule with EOA and ZK Email-based recovery #66 

- Added the `SimpleRecoveryModule` contract to support account recovery using both EOA guardians and ZK email proof.

files: SimpleRecoveryModule.*

Test: forge test --match-path test/SimpleRecoveryModule.t.sol
