### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zk-email/email-recovery",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Smart account module and related contracts to enable email recovery for validators",
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -33,15 +33,11 @@
   "dependencies": {
     "@matterlabs/era-contracts": "github:matter-labs/era-contracts",
     "@openzeppelin/contracts-upgradeable": "5.0.1",
-    "@rhinestone/modulekit": "0.4.13",
+    "@rhinestone/modulekit": "0.5.2",
+    "@safe-global/safe-contracts": "1.4.1-2",
     "@zk-email/contracts": "6.3.2",
-    "@zk-email/ether-email-auth-contracts": "1.0.2",
+    "@zk-email/ether-email-auth-contracts": "1.1.0",
     "solidity-stringutils": "github:LayerZero-Labs/solidity-stringutils"
-  },
-  "pnpm": {
-    "overrides": {
-      "erc7579": "github:erc7579/erc7579-implementation#b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56"
-    }
   },
   "files": [
     "src",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  erc7579: github:erc7579/erc7579-implementation#b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56
-
 importers:
 
   .:
@@ -18,14 +15,17 @@ importers:
         specifier: 5.0.1
         version: 5.0.1(@openzeppelin/contracts@5.1.0)
       '@rhinestone/modulekit':
-        specifier: 0.4.13
-        version: 0.4.13(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))(typescript@4.9.5)
+        specifier: 0.5.2
+        version: 0.5.2(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))(typescript@4.9.5)
+      '@safe-global/safe-contracts':
+        specifier: 1.4.1-2
+        version: 1.4.1-2(ethers@5.7.2)
       '@zk-email/contracts':
         specifier: 6.3.2
         version: 6.3.2
       '@zk-email/ether-email-auth-contracts':
-        specifier: 1.0.2
-        version: 1.0.2
+        specifier: 1.1.0
+        version: 1.1.0
       solidity-stringutils:
         specifier: github:LayerZero-Labs/solidity-stringutils
         version: https://codeload.github.com/LayerZero-Labs/solidity-stringutils/tar.gz/eb21d6b502c2741145ab2a90f5f5b4fda9dfb218
@@ -320,37 +320,18 @@ packages:
   '@prb/math@4.1.0':
     resolution: {integrity: sha512-ef5Xrlh3BeX4xT5/Wi810dpEPq2bYPndRxgFIaKSU1F/Op/s8af03kyom+mfU7gEpvfIZ46xu8W0duiHplbBMg==}
 
-  '@rhinestone/checknsignatures@https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/ef8e54b1df861681059b60be32ef9576030ea984':
-    resolution: {tarball: https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/ef8e54b1df861681059b60be32ef9576030ea984}
-    version: 0.0.1
+  '@rhinestone/erc4337-validation@0.0.4':
+    resolution: {integrity: sha512-9GPvOvmM9j5ZZRCFeujPacUyByRnrGL22/5177hRzXh5mLq/A22EyvVIVNcsWMvNiLcHAV4dkkKpXaljxNOT9A==}
 
-  '@rhinestone/erc4337-validation@0.0.1-alpha.2':
-    resolution: {integrity: sha512-sxBSHoR0hV0rN2bv5HfINHR3RyBChfd0OWH0TP8nlA9FolJ1EezLByxcyrvAgi2QLQ2Zf2zVcNky1qYdfF4NjQ==}
-
-  '@rhinestone/erc4337-validation@0.0.1-alpha.5':
-    resolution: {integrity: sha512-yOrYyQBrT0JfHb+rjvx4pqk8uItKxEtn7n8z3k0qbZTzkXaNS9pCUBsTxy0kp6T2SNUrbQ8I4DMSiyGqjdh2ng==}
-
-  '@rhinestone/module-bases@https://codeload.github.com/rhinestonewtf/module-bases/tar.gz/ed01be1780af30dee8a0877b8f2d494842290fb2':
-    resolution: {tarball: https://codeload.github.com/rhinestonewtf/module-bases/tar.gz/ed01be1780af30dee8a0877b8f2d494842290fb2}
-    version: 0.0.1
-
-  '@rhinestone/modulekit@0.4.13':
-    resolution: {integrity: sha512-kuzU298oPIt4rLXPRgxVW9gHIj7x+iAjOX+eC3iNs8zt1KxatmWv+pDI+mze9vjgsp9u4j6j6h+MYmaloSLCEQ==}
-
-  '@rhinestone/registry@https://codeload.github.com/rhinestonewtf/registry/tar.gz/1371979a97293e0c6188afcd923784f6a718ae7d':
-    resolution: {tarball: https://codeload.github.com/rhinestonewtf/registry/tar.gz/1371979a97293e0c6188afcd923784f6a718ae7d}
-    version: 1.0.0
-
-  '@rhinestone/safe7579@https://codeload.github.com/rhinestonewtf/safe7579/tar.gz/33f110f08ed5fcab75c29d7cfb93f7f3e4da76a7':
-    resolution: {tarball: https://codeload.github.com/rhinestonewtf/safe7579/tar.gz/33f110f08ed5fcab75c29d7cfb93f7f3e4da76a7}
-    version: 1.0.0
+  '@rhinestone/modulekit@0.5.2':
+    resolution: {integrity: sha512-x5IJJI68LfufGF68SciB4Juu9Nw8dmkVGtvEFg4u674T2l/9y7GnNN8zh+ACmQT+0xEmT4WS8jRZqkQCiEYqgg==}
 
   '@rhinestone/sentinellist@https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/e722c5cc68c570d535bc3c9f85b3ce90cdc38807':
     resolution: {tarball: https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/e722c5cc68c570d535bc3c9f85b3ce90cdc38807}
     version: 1.0.1
 
-  '@safe-global/safe-contracts@1.4.1':
-    resolution: {integrity: sha512-fP1jewywSwsIniM04NsqPyVRFKPMAuirC3ftA/TA4X3Zc5EnwQp/UCJUU2PL/37/z/jMo8UUaJ+pnFNWmMU7dQ==}
+  '@safe-global/safe-contracts@1.4.1-2':
+    resolution: {integrity: sha512-UFiqZOamt1lDbyQ16lpzBE8mDdzfnQ3OBftll1erLlwIrdfmhePicQqfLquvyXA8AlqPWQ3ktz1DzpC9UcN+JQ==}
     peerDependencies:
       ethers: 5.4.0
 
@@ -403,6 +384,9 @@ packages:
 
   '@solidity-parser/parser@0.18.0':
     resolution: {integrity: sha512-yfORGUIPgLck41qyN7nbwJRAx17/jAIXCTanHOJZhB6PJ1iAk/84b/xlsVKFSyNyLXIj0dhppoE0+CRws7wlzA==}
+
+  '@solidity-parser/parser@0.19.0':
+    resolution: {integrity: sha512-RV16k/qIxW/wWc+mLzV3ARyKUaMUTBy9tOLMzFhtNSKYeTAanQ3a5MudJKf/8arIFnA2L27SNjarQKmFg0w/jA==}
 
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
@@ -466,15 +450,11 @@ packages:
   '@zk-email/contracts@6.3.2':
     resolution: {integrity: sha512-+JW0aZMlcrT66lsLqpyxHoGrOT3cMsfBnRinJ8wgXJit4rbZSRYKqVi42dGMyJVvpiJ8O9VQ5hbeYn/fpQKUxw==}
 
-  '@zk-email/ether-email-auth-contracts@1.0.2':
-    resolution: {integrity: sha512-mUAu7QQ0/kjoDkN6vPEZa4so5lUuQzSvu45yWMTDJCANwLIbCLVAMA2koS63MDDAsYK9mrfWGEsJvGqmN7S4Qg==}
+  '@zk-email/ether-email-auth-contracts@1.1.0':
+    resolution: {integrity: sha512-JXTIONqohwXOgkc2xaX46ed3yyrOuhHzYu6gR/X3tEVTVm/83P9nozi7p4LEAy4uIKdK5xf391RUjTReUyCQpQ==}
 
   abbrev@1.0.9:
     resolution: {integrity: sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==}
-
-  accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/6f02f5a28a20e804d0410b4b5b570dd4b076dcf9:
-    resolution: {tarball: https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/6f02f5a28a20e804d0410b4b5b570dd4b076dcf9}
-    version: 0.7.0
 
   accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6:
     resolution: {tarball: https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6}
@@ -848,10 +828,6 @@ packages:
     resolution: {tarball: https://codeload.github.com/matter-labs/era-contracts/tar.gz/aafee035db892689df3f7afe4b89fd6467a39313}
     version: 0.1.0
 
-  erc7579-implementation@https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56:
-    resolution: {tarball: https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56}
-    version: 0.3.1
-
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
@@ -993,13 +969,13 @@ packages:
       debug:
         optional: true
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/0e7097750918380d84dd3cfdef595bee74dabb70:
-    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/0e7097750918380d84dd3cfdef595bee74dabb70}
-    version: 1.9.4
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/8a225d81aa8e2e013580564588c79abb65eacc9e:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/8a225d81aa8e2e013580564588c79abb65eacc9e}
+    version: 1.9.3
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/ae570fec082bfe1c1f45b0acca4a2b4f84d345ce:
-    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/ae570fec082bfe1c1f45b0acca4a2b4f84d345ce}
-    version: 1.7.6
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/b5a86914561f38735ef1fc357685de3e7c92dc48:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/b5a86914561f38735ef1fc357685de3e7c92dc48}
+    version: 1.9.5
 
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
@@ -1310,10 +1286,6 @@ packages:
   keccak@3.0.4:
     resolution: {integrity: sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==}
     engines: {node: '>=10.0.0'}
-
-  kernel@https://codeload.github.com/kopy-kat/kernel/tar.gz/acc457ce5169929ce3ce0f06a9540f85ccc8b25f:
-    resolution: {tarball: https://codeload.github.com/kopy-kat/kernel/tar.gz/acc457ce5169929ce3ce0f06a9540f85ccc8b25f}
-    version: 3.0.0
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1755,13 +1727,9 @@ packages:
   solady@0.0.123:
     resolution: {integrity: sha512-F/B8OMCplGsS4FrdPrnEG0xdg8HKede5PwC+Rum8soj/LWxfKckA0p+Uwnlbgey2iI82IHvmSOCNhsdbA+lUrw==}
 
-  solady@https://codeload.github.com/vectorized/solady/tar.gz/4c8be46dbc8d2d319cc6acf058a6aa79c0b78eb1:
-    resolution: {tarball: https://codeload.github.com/vectorized/solady/tar.gz/4c8be46dbc8d2d319cc6acf058a6aa79c0b78eb1}
-    version: 0.0.267
-
-  solady@https://codeload.github.com/vectorized/solady/tar.gz/9deb9ed36a27261a8745db5b7cd7f4cdc3b1cd4e:
-    resolution: {tarball: https://codeload.github.com/vectorized/solady/tar.gz/9deb9ed36a27261a8745db5b7cd7f4cdc3b1cd4e}
-    version: 0.0.168
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/de9aee59648862bb98affd578248d1e75c7073ad:
+    resolution: {tarball: https://codeload.github.com/vectorized/solady/tar.gz/de9aee59648862bb98affd578248d1e75c7073ad}
+    version: 0.0.288
 
   solarray@https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684:
     resolution: {tarball: https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684}
@@ -1772,8 +1740,8 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  solhint@4.5.4:
-    resolution: {integrity: sha512-Cu1XiJXub2q1eCr9kkJ9VPv1sGcmj3V7Zb76B0CoezDOB9bu3DxKIFFH7ggCl9fWpEPD6xBmRLfZrYijkVmujQ==}
+  solhint@5.0.4:
+    resolution: {integrity: sha512-GzKBjJ8S2utRsEOCJXhY2H35gwHGmoQY2rQXcPGT4XdDlzwgGYz0Ovo9Xm7cmWYgSo121uF+5tiwrqQT2b+Rtw==}
     hasBin: true
 
   solidity-coverage@0.8.13:
@@ -2483,41 +2451,15 @@ snapshots:
 
   '@prb/math@4.1.0': {}
 
-  '@rhinestone/checknsignatures@https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/ef8e54b1df861681059b60be32ef9576030ea984':
-    dependencies:
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/0e7097750918380d84dd3cfdef595bee74dabb70
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/4c8be46dbc8d2d319cc6acf058a6aa79c0b78eb1
-
-  '@rhinestone/erc4337-validation@0.0.1-alpha.2(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))(typescript@4.9.5)':
+  '@rhinestone/erc4337-validation@0.0.4(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))':
     dependencies:
       '@openzeppelin/contracts': 5.0.1
       account-abstraction: accountabstraction@https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       account-abstraction-v0.6: accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/0e7097750918380d84dd3cfdef595bee74dabb70
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/8a225d81aa8e2e013580564588c79abb65eacc9e
       prettier: 2.8.8
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/4c8be46dbc8d2d319cc6acf058a6aa79c0b78eb1
-      solhint: 4.5.4(typescript@4.9.5)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - ethers
-      - hardhat
-      - lodash
-      - supports-color
-      - typechain
-      - typescript
-      - utf-8-validate
-
-  '@rhinestone/erc4337-validation@0.0.1-alpha.5(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))':
-    dependencies:
-      '@openzeppelin/contracts': 5.0.1
-      account-abstraction: accountabstraction@https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      account-abstraction-v0.6: accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/0e7097750918380d84dd3cfdef595bee74dabb70
-      prettier: 2.8.8
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/4c8be46dbc8d2d319cc6acf058a6aa79c0b78eb1
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/de9aee59648862bb98affd578248d1e75c7073ad
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2528,70 +2470,19 @@ snapshots:
       - typechain
       - utf-8-validate
 
-  '@rhinestone/module-bases@https://codeload.github.com/rhinestonewtf/module-bases/tar.gz/ed01be1780af30dee8a0877b8f2d494842290fb2(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))':
-    dependencies:
-      '@ERC4337/account-abstraction': accountabstraction@https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      erc7579: erc7579-implementation@https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/0e7097750918380d84dd3cfdef595bee74dabb70
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - ethers
-      - hardhat
-      - lodash
-      - supports-color
-      - typechain
-      - utf-8-validate
-
-  '@rhinestone/modulekit@0.4.13(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))(typescript@4.9.5)':
+  '@rhinestone/modulekit@0.5.2(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))(typescript@4.9.5)':
     dependencies:
       '@ERC4337/account-abstraction': accountabstraction@https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       '@ERC4337/account-abstraction-v0.6': accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       '@prb/math': 4.1.0
-      '@rhinestone/erc4337-validation': 0.0.1-alpha.5(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      '@rhinestone/module-bases': https://codeload.github.com/rhinestonewtf/module-bases/tar.gz/ed01be1780af30dee8a0877b8f2d494842290fb2(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      '@rhinestone/registry': https://codeload.github.com/rhinestonewtf/registry/tar.gz/1371979a97293e0c6188afcd923784f6a718ae7d
-      '@rhinestone/safe7579': https://codeload.github.com/rhinestonewtf/safe7579/tar.gz/33f110f08ed5fcab75c29d7cfb93f7f3e4da76a7(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))(typescript@4.9.5)
+      '@rhinestone/erc4337-validation': 0.0.4(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       '@rhinestone/sentinellist': https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/e722c5cc68c570d535bc3c9f85b3ce90cdc38807
-      '@safe-global/safe-contracts': 1.4.1(ethers@5.7.2)
-      '@zerodev/kernel': kernel@https://codeload.github.com/kopy-kat/kernel/tar.gz/acc457ce5169929ce3ce0f06a9540f85ccc8b25f
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
-      erc7579: erc7579-implementation@https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       excessively-safe-call: '@nomad-xyz/excessively-safe-call@https://codeload.github.com/nomad-xyz/ExcessivelySafeCall/tar.gz/81cd99ce3e69117d665d7601c330ea03b97acce0'
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/0e7097750918380d84dd3cfdef595bee74dabb70
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/4c8be46dbc8d2d319cc6acf058a6aa79c0b78eb1
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/b5a86914561f38735ef1fc357685de3e7c92dc48
+      solady: https://codeload.github.com/vectorized/solady/tar.gz/de9aee59648862bb98affd578248d1e75c7073ad
       solarray: https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - ethers
-      - hardhat
-      - lodash
-      - supports-color
-      - typechain
-      - typescript
-      - utf-8-validate
-
-  '@rhinestone/registry@https://codeload.github.com/rhinestonewtf/registry/tar.gz/1371979a97293e0c6188afcd923784f6a718ae7d':
-    dependencies:
-      '@openzeppelin/contracts': 5.0.1
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/ae570fec082bfe1c1f45b0acca4a2b4f84d345ce
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/9deb9ed36a27261a8745db5b7cd7f4cdc3b1cd4e
-
-  '@rhinestone/safe7579@https://codeload.github.com/rhinestonewtf/safe7579/tar.gz/33f110f08ed5fcab75c29d7cfb93f7f3e4da76a7(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))(typescript@4.9.5)':
-    dependencies:
-      '@ERC4337/account-abstraction': accountabstraction@https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      '@ERC4337/account-abstraction-v0.6': accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      '@rhinestone/checknsignatures': https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/ef8e54b1df861681059b60be32ef9576030ea984
-      '@rhinestone/erc4337-validation': 0.0.1-alpha.2(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))(typescript@4.9.5)
-      '@rhinestone/module-bases': https://codeload.github.com/rhinestonewtf/module-bases/tar.gz/ed01be1780af30dee8a0877b8f2d494842290fb2(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      '@rhinestone/sentinellist': https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/e722c5cc68c570d535bc3c9f85b3ce90cdc38807
-      '@safe-global/safe-contracts': 1.4.1(ethers@5.7.2)
-      ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
-      erc7579: erc7579-implementation@https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/0e7097750918380d84dd3cfdef595bee74dabb70
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/4c8be46dbc8d2d319cc6acf058a6aa79c0b78eb1
-      solarray: https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684
+      solhint: 5.0.4(typescript@4.9.5)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2605,9 +2496,9 @@ snapshots:
 
   '@rhinestone/sentinellist@https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/e722c5cc68c570d535bc3c9f85b3ce90cdc38807':
     dependencies:
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/0e7097750918380d84dd3cfdef595bee74dabb70
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/b5a86914561f38735ef1fc357685de3e7c92dc48
 
-  '@safe-global/safe-contracts@1.4.1(ethers@5.7.2)':
+  '@safe-global/safe-contracts@1.4.1-2(ethers@5.7.2)':
     dependencies:
       ethers: 5.7.2
 
@@ -2688,6 +2579,8 @@ snapshots:
 
   '@solidity-parser/parser@0.18.0': {}
 
+  '@solidity-parser/parser@0.19.0': {}
+
   '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
@@ -2760,7 +2653,7 @@ snapshots:
       '@openzeppelin/contracts-upgradeable': 5.0.1(@openzeppelin/contracts@5.1.0)
       dotenv: 16.4.5
 
-  '@zk-email/ether-email-auth-contracts@1.0.2':
+  '@zk-email/ether-email-auth-contracts@1.1.0':
     dependencies:
       '@matterlabs/zksync-contracts': 0.6.1(@openzeppelin/contracts-upgradeable@5.0.1(@openzeppelin/contracts@5.1.0))(@openzeppelin/contracts@5.1.0)
       '@openzeppelin/contracts': 5.1.0
@@ -2770,33 +2663,6 @@ snapshots:
       solidity-stringutils: https://codeload.github.com/LayerZero-Labs/solidity-stringutils/tar.gz/eb21d6b502c2741145ab2a90f5f5b4fda9dfb218
 
   abbrev@1.0.9: {}
-
-  accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/6f02f5a28a20e804d0410b4b5b570dd4b076dcf9(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5)):
-    dependencies:
-      '@nomiclabs/hardhat-etherscan': 2.1.8(hardhat@2.22.14(typescript@4.9.5))
-      '@openzeppelin/contracts': 5.1.0
-      '@thehubbleproject/bls': 0.5.1
-      '@typechain/hardhat': 2.3.1(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      '@types/debug': 4.1.12
-      '@types/mocha': 9.1.1
-      debug: 4.3.7(supports-color@8.1.1)
-      ethereumjs-util: 7.1.5
-      ethereumjs-wallet: 1.0.2
-      hardhat-deploy: 0.11.45
-      hardhat-deploy-ethers: 0.3.0-beta.13(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))
-      solidity-coverage: 0.8.13(hardhat@2.22.14(typescript@4.9.5))
-      source-map-support: 0.5.21
-      table: 6.8.2
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - ethers
-      - hardhat
-      - lodash
-      - supports-color
-      - typechain
-      - utf-8-validate
 
   accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5)):
     dependencies:
@@ -3230,23 +3096,6 @@ snapshots:
 
   era-contracts@https://codeload.github.com/matter-labs/era-contracts/tar.gz/aafee035db892689df3f7afe4b89fd6467a39313: {}
 
-  erc7579-implementation@https://codeload.github.com/erc7579/erc7579-implementation/tar.gz/b3f8bcb2df3aae3217213ffa8b7a87c1eb42ec56(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5)):
-    dependencies:
-      '@rhinestone/sentinellist': https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/e722c5cc68c570d535bc3c9f85b3ce90cdc38807
-      account-abstraction: accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/6f02f5a28a20e804d0410b4b5b570dd4b076dcf9(ethers@5.7.2)(hardhat@2.22.14(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/0e7097750918380d84dd3cfdef595bee74dabb70
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/4c8be46dbc8d2d319cc6acf058a6aa79c0b78eb1
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - ethers
-      - hardhat
-      - lodash
-      - supports-color
-      - typechain
-      - utf-8-validate
-
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
@@ -3451,9 +3300,9 @@ snapshots:
     optionalDependencies:
       debug: 4.3.7(supports-color@8.1.1)
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/0e7097750918380d84dd3cfdef595bee74dabb70: {}
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/8a225d81aa8e2e013580564588c79abb65eacc9e: {}
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/ae570fec082bfe1c1f45b0acca4a2b4f84d345ce: {}
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/b5a86914561f38735ef1fc357685de3e7c92dc48: {}
 
   form-data-encoder@2.1.4: {}
 
@@ -3855,8 +3704,6 @@ snapshots:
       node-addon-api: 2.0.2
       node-gyp-build: 4.8.2
       readable-stream: 3.6.2
-
-  kernel@https://codeload.github.com/kopy-kat/kernel/tar.gz/acc457ce5169929ce3ce0f06a9540f85ccc8b25f: {}
 
   keyv@4.5.4:
     dependencies:
@@ -4284,9 +4131,7 @@ snapshots:
 
   solady@0.0.123: {}
 
-  solady@https://codeload.github.com/vectorized/solady/tar.gz/4c8be46dbc8d2d319cc6acf058a6aa79c0b78eb1: {}
-
-  solady@https://codeload.github.com/vectorized/solady/tar.gz/9deb9ed36a27261a8745db5b7cd7f4cdc3b1cd4e: {}
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/de9aee59648862bb98affd578248d1e75c7073ad: {}
 
   solarray@https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684: {}
 
@@ -4302,9 +4147,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  solhint@4.5.4(typescript@4.9.5):
+  solhint@5.0.4(typescript@4.9.5):
     dependencies:
-      '@solidity-parser/parser': 0.18.0
+      '@solidity-parser/parser': 0.19.0
       ajv: 6.12.6
       antlr4: 4.13.2
       ast-parents: 0.0.1

--- a/remappings.txt
+++ b/remappings.txt
@@ -12,6 +12,7 @@ account-abstraction-v0.6/=node_modules/@ERC4337/account-abstraction-v0.6/contrac
 @openzeppelin/=node_modules/@openzeppelin/
 @safe-global/=node_modules/@safe-global/
 ds-test/=node_modules/ds-test/src/
+erc7579/interfaces/=node_modules/@rhinestone/modulekit/src/accounts/common/interfaces/
 erc7579/=node_modules/erc7579/src/
 forge-std/=node_modules/forge-std/src/
 solady/=node_modules/solady/src/

--- a/script/DeploySafeRecovery.s.sol
+++ b/script/DeploySafeRecovery.s.sol
@@ -9,9 +9,6 @@ import { EmailRecoveryUniversalFactory } from "src/factories/EmailRecoveryUniver
 import { EmailAuth } from "@zk-email/ether-email-auth-contracts/src/EmailAuth.sol";
 import { UserOverrideableDKIMRegistry } from "@zk-email/contracts/UserOverrideableDKIMRegistry.sol";
 
-import { Safe7579 } from "safe7579/Safe7579.sol";
-import { Safe7579Launchpad } from "safe7579/Safe7579Launchpad.sol";
-import { IERC7484 } from "safe7579/interfaces/IERC7484.sol";
 import { BaseDeployScript } from "./BaseDeployScript.s.sol";
 
 // 1. `source .env`
@@ -31,8 +28,6 @@ contract DeploySafeRecovery_Script is BaseDeployScript {
 
     function run() public override {
         super.run();
-        address entryPoint = address(0x0000000071727De22E5E9d8BAf0edAc6f37da032);
-        IERC7484 registry = IERC7484(0xe0cde9239d16bEf05e62Bbf7aA93e420f464c826);
 
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
         verifier = vm.envOr("VERIFIER", address(0));
@@ -74,14 +69,8 @@ contract DeploySafeRecovery_Script is BaseDeployScript {
             address(dkim)
         );
 
-        address safe7579 = address(new Safe7579{ salt: bytes32(salt) }());
-        address safe7579Launchpad =
-            address(new Safe7579Launchpad{ salt: bytes32(salt) }(entryPoint, registry));
-
         console.log("Deployed Email Recovery Module at  ", vm.toString(module));
         console.log("Deployed Email Recovery Handler at ", vm.toString(commandHandler));
-        console.log("Deployed Safe 7579 at              ", vm.toString(safe7579));
-        console.log("Deployed Safe 7579 Launchpad at    ", vm.toString(safe7579Launchpad));
 
         vm.stopBroadcast();
     }

--- a/script/DeploySafeRecoveryWithAccountHiding.s.sol
+++ b/script/DeploySafeRecoveryWithAccountHiding.s.sol
@@ -9,9 +9,6 @@ import { AccountHidingRecoveryCommandHandler } from
 import { EmailRecoveryUniversalFactory } from "src/factories/EmailRecoveryUniversalFactory.sol";
 import { EmailAuth } from "@zk-email/ether-email-auth-contracts/src/EmailAuth.sol";
 
-import { Safe7579 } from "safe7579/Safe7579.sol";
-import { Safe7579Launchpad } from "safe7579/Safe7579Launchpad.sol";
-import { IERC7484 } from "safe7579/interfaces/IERC7484.sol";
 import { BaseDeployScript } from "./BaseDeployScript.s.sol";
 
 // 1. `source .env`
@@ -31,8 +28,6 @@ contract DeploySafeRecoveryWithAccountHiding_Script is BaseDeployScript {
 
     function run() public override {
         super.run();
-        address entryPoint = address(0x0000000071727De22E5E9d8BAf0edAc6f37da032);
-        IERC7484 registry = IERC7484(0xe0cde9239d16bEf05e62Bbf7aA93e420f464c826);
 
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
         verifier = vm.envOr("VERIFIER", address(0));
@@ -74,14 +69,8 @@ contract DeploySafeRecoveryWithAccountHiding_Script is BaseDeployScript {
             dkim
         );
 
-        address safe7579 = address(new Safe7579{ salt: bytes32(uint256(0)) }());
-        address safe7579Launchpad =
-            address(new Safe7579Launchpad{ salt: bytes32(uint256(0)) }(entryPoint, registry));
-
         console.log("Deployed Email Recovery Module at  ", vm.toString(module));
         console.log("Deployed Email Recovery Handler at ", vm.toString(commandHandler));
-        console.log("Deployed Safe 7579 at              ", vm.toString(safe7579));
-        console.log("Deployed Safe 7579 Launchpad at    ", vm.toString(safe7579Launchpad));
 
         vm.stopBroadcast();
     }

--- a/src/test/OwnableValidator.sol
+++ b/src/test/OwnableValidator.sol
@@ -76,19 +76,6 @@ contract OwnableValidator is ERC7579ValidatorBase {
             : EIP1271_FAILED;
     }
 
-    function validateSignatureWithData(
-        bytes32 hash,
-        bytes calldata signature,
-        bytes calldata data
-    )
-        external
-        view
-        override
-        returns (bool)
-    {
-        return false;
-    }
-
     function changeOwner(address newOwner) external {
         owners[msg.sender] = newOwner;
     }

--- a/test/integration/EmailRecoveryManager/EmailRecoveryManager.integration.t.sol
+++ b/test/integration/EmailRecoveryManager/EmailRecoveryManager.integration.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { ModuleKitHelpers, ModuleKitUserOp } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
+
 import { EmailAuthMsg } from "@zk-email/ether-email-auth-contracts/src/EmailAuth.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -18,7 +19,6 @@ contract EmailRecoveryManager_Integration_Test is
     OwnableValidatorRecovery_UniversalEmailRecoveryModule_Base
 {
     using ModuleKitHelpers for *;
-    using ModuleKitUserOp for *;
 
     function setUp() public override {
         super.setUp();

--- a/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModule.t.sol
+++ b/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModule.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers, AccountInstance } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { EmailAuthMsg } from "@zk-email/ether-email-auth-contracts/src/EmailAuth.sol";
 import { EmailAccountRecovery } from
     "@zk-email/ether-email-auth-contracts/src/EmailAccountRecovery.sol";

--- a/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { ModuleKitHelpers, ModuleKitUserOp } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR, MODULE_TYPE_VALIDATOR } from "modulekit/external/ERC7579.sol";
+import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
+import {
+    MODULE_TYPE_EXECUTOR,
+    MODULE_TYPE_VALIDATOR
+} from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { AccountHidingRecoveryCommandHandler } from
     "src/handlers/AccountHidingRecoveryCommandHandler.sol";
@@ -12,7 +15,6 @@ import { BaseTest, CommandHandlerType } from "../../../Base.t.sol";
 
 abstract contract OwnableValidatorRecovery_EmailRecoveryModule_Base is BaseTest {
     using ModuleKitHelpers for *;
-    using ModuleKitUserOp for *;
     using Strings for uint256;
     using Strings for address;
 

--- a/test/integration/OwnableValidatorRecovery/UniversalEmailRecoveryModule/UniversalEmailRecoveryModule.t.sol
+++ b/test/integration/OwnableValidatorRecovery/UniversalEmailRecoveryModule/UniversalEmailRecoveryModule.t.sol
@@ -2,7 +2,10 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR, MODULE_TYPE_VALIDATOR } from "modulekit/external/ERC7579.sol";
+import {
+    MODULE_TYPE_EXECUTOR,
+    MODULE_TYPE_VALIDATOR
+} from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { EmailAuthMsg } from "@zk-email/ether-email-auth-contracts/src/EmailAuth.sol";
 
 import { IEmailRecoveryManager } from "src/interfaces/IEmailRecoveryManager.sol";

--- a/test/integration/OwnableValidatorRecovery/UniversalEmailRecoveryModule/UniversalEmailRecoveryModuleBase.t.sol
+++ b/test/integration/OwnableValidatorRecovery/UniversalEmailRecoveryModule/UniversalEmailRecoveryModuleBase.t.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { ModuleKitHelpers, ModuleKitUserOp } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR, MODULE_TYPE_VALIDATOR } from "modulekit/external/ERC7579.sol";
+import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
+import {
+    MODULE_TYPE_EXECUTOR,
+    MODULE_TYPE_VALIDATOR
+} from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
@@ -15,7 +18,6 @@ import { BaseTest, CommandHandlerType } from "../../../Base.t.sol";
 
 abstract contract OwnableValidatorRecovery_UniversalEmailRecoveryModule_Base is BaseTest {
     using ModuleKitHelpers for *;
-    using ModuleKitUserOp for *;
     using Strings for uint256;
     using Strings for address;
 

--- a/test/integration/SafeRecovery/SafeIntegrationBase.t.sol
+++ b/test/integration/SafeRecovery/SafeIntegrationBase.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { EmailAuthMsg, EmailProof } from "@zk-email/ether-email-auth-contracts/src/EmailAuth.sol";
 import { CommandUtils } from "@zk-email/ether-email-auth-contracts/src/libraries/CommandUtils.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/test/integration/SafeRecovery/SafeRecovery.t.sol
+++ b/test/integration/SafeRecovery/SafeRecovery.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { ModuleKitHelpers, ModuleKitUserOp } from "modulekit/ModuleKit.sol";
+import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
 import { Safe } from "@safe-global/safe-contracts/contracts/Safe.sol";
 
 import { SafeIntegrationBase } from "./SafeIntegrationBase.t.sol";
@@ -10,7 +10,6 @@ import { GuardianStorage, GuardianStatus } from "src/libraries/EnumerableGuardia
 
 contract SafeRecovery_Integration_Test is SafeIntegrationBase {
     using ModuleKitHelpers for *;
-    using ModuleKitUserOp for *;
 
     function setUp() public override {
         super.setUp();

--- a/test/unit/EmailRecoveryManager/acceptGuardian.t.sol
+++ b/test/unit/EmailRecoveryManager/acceptGuardian.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { ModuleKitHelpers, ModuleKitUserOp } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { IEmailRecoveryManager } from "src/interfaces/IEmailRecoveryManager.sol";
 import { IGuardianManager } from "src/interfaces/IGuardianManager.sol";
@@ -12,7 +12,6 @@ import { CommandHandlerType } from "../../Base.t.sol";
 
 contract EmailRecoveryManager_acceptGuardian_Test is UnitBase {
     using ModuleKitHelpers for *;
-    using ModuleKitUserOp for *;
     using Strings for uint256;
 
     bytes[] public commandParams;

--- a/test/unit/EmailRecoveryManager/configureRecovery.t.sol
+++ b/test/unit/EmailRecoveryManager/configureRecovery.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { IEmailRecoveryManager } from "src/interfaces/IEmailRecoveryManager.sol";
 import { GuardianStorage, GuardianStatus } from "src/libraries/EnumerableGuardianMap.sol";
 import { IGuardianManager } from "src/interfaces/IGuardianManager.sol";

--- a/test/unit/EmailRecoveryManager/isActivated.t.sol
+++ b/test/unit/EmailRecoveryManager/isActivated.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { UnitBase } from "../UnitBase.t.sol";
 
 contract EmailRecoveryManager_isActivated_Test is UnitBase {

--- a/test/unit/EmailRecoveryManager/processRecovery.t.sol
+++ b/test/unit/EmailRecoveryManager/processRecovery.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { ModuleKitHelpers, ModuleKitUserOp } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { UnitBase } from "../UnitBase.t.sol";
 import { CommandHandlerType } from "../../Base.t.sol";
@@ -13,7 +13,6 @@ import { IGuardianManager } from "src/interfaces/IGuardianManager.sol";
 
 contract EmailRecoveryManager_processRecovery_Test is UnitBase {
     using ModuleKitHelpers for *;
-    using ModuleKitUserOp for *;
     using Strings for uint256;
 
     string public recoveryDataHashString;

--- a/test/unit/EmailRecoveryManager/updateRecoveryConfig.t.sol
+++ b/test/unit/EmailRecoveryManager/updateRecoveryConfig.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { UnitBase } from "../UnitBase.t.sol";
 import { UniversalEmailRecoveryModule } from "src/modules/UniversalEmailRecoveryModule.sol";
 import { IEmailRecoveryManager } from "src/interfaces/IEmailRecoveryManager.sol";

--- a/test/unit/GuardianManager/addGuardian.t.sol
+++ b/test/unit/GuardianManager/addGuardian.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { UnitBase } from "../UnitBase.t.sol";
 import { IGuardianManager } from "src/interfaces/IGuardianManager.sol";
 import { GuardianStorage, GuardianStatus } from "src/libraries/EnumerableGuardianMap.sol";

--- a/test/unit/GuardianManager/setupGuardians.t.sol
+++ b/test/unit/GuardianManager/setupGuardians.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { UnitBase } from "../UnitBase.t.sol";
 import { GuardianStorage, GuardianStatus } from "src/libraries/EnumerableGuardianMap.sol";
 import { IGuardianManager } from "src/interfaces/IGuardianManager.sol";

--- a/test/unit/GuardianManager/updateGuardianStatus.t.sol
+++ b/test/unit/GuardianManager/updateGuardianStatus.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { GuardianStorage, GuardianStatus } from "src/libraries/EnumerableGuardianMap.sol";
 import { UnitBase } from "../UnitBase.t.sol";
 import { IGuardianManager } from "src/interfaces/IGuardianManager.sol";

--- a/test/unit/SafeUnitBase.t.sol
+++ b/test/unit/SafeUnitBase.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 

--- a/test/unit/UnitBase.t.sol
+++ b/test/unit/UnitBase.t.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { ModuleKitHelpers, ModuleKitUserOp } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR, MODULE_TYPE_VALIDATOR } from "modulekit/external/ERC7579.sol";
+import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
+import {
+    MODULE_TYPE_EXECUTOR,
+    MODULE_TYPE_VALIDATOR
+} from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
@@ -15,7 +18,6 @@ import { EmailRecoveryUniversalFactory } from "src/factories/EmailRecoveryUniver
 
 abstract contract UnitBase is BaseTest {
     using ModuleKitHelpers for *;
-    using ModuleKitUserOp for *;
     using Strings for uint256;
 
     EmailRecoveryFactory public emailRecoveryFactory;

--- a/test/unit/handlers/AccountHidingRecoveryCommandHandler/extractRecoveredAccountFromRecoveryCommand.t.sol
+++ b/test/unit/handlers/AccountHidingRecoveryCommandHandler/extractRecoveredAccountFromRecoveryCommand.t.sol
@@ -18,7 +18,7 @@ contract AccountHidingRecoveryCommandHandler_extractRecoveredAccountFromRecovery
         accountHidingRecoveryCommandHandler = new AccountHidingRecoveryCommandHandler();
     }
 
-    function test_ExtractRecoveredAccountFromRecoveryCommand_FailsWhenHashNotStored() public {
+    function test_ExtractRecoveredAccountFromRecoveryCommand_FailsWhenHashNotStored() public view {
         bytes32 accountHash = keccak256(abi.encodePacked(accountAddress1));
         string memory accountHashString = uint256(accountHash).toHexString(32);
         string memory recoveryDataHashString = uint256(recoveryDataHash).toHexString(32);

--- a/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { ModuleKitHelpers, ModuleKitUserOp } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR, MODULE_TYPE_VALIDATOR } from "modulekit/external/ERC7579.sol";
+import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
+import {
+    MODULE_TYPE_EXECUTOR,
+    MODULE_TYPE_VALIDATOR
+} from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
@@ -14,7 +17,6 @@ import { EmailRecoveryFactory } from "src/factories/EmailRecoveryFactory.sol";
 
 abstract contract EmailRecoveryModuleBase is BaseTest {
     using ModuleKitHelpers for *;
-    using ModuleKitUserOp for *;
     using Strings for uint256;
 
     EmailRecoveryFactory public emailRecoveryFactory;

--- a/test/unit/modules/EmailRecoveryModule/canStartRecoveryRequest.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/canStartRecoveryRequest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { IGuardianManager } from "src/interfaces/IGuardianManager.sol";
 import { EmailRecoveryModuleBase } from "./EmailRecoveryModuleBase.t.sol";
 

--- a/test/unit/modules/EmailRecoveryModule/isInitialized.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/isInitialized.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
 import { EmailRecoveryModuleBase } from "./EmailRecoveryModuleBase.t.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 
 contract EmailRecoveryModule_isInitialized_Test is EmailRecoveryModuleBase {
     using ModuleKitHelpers for *;

--- a/test/unit/modules/EmailRecoveryModule/isModuleType.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/isModuleType.t.sol
@@ -3,7 +3,10 @@ pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
 import { EmailRecoveryModuleBase } from "./EmailRecoveryModuleBase.t.sol";
-import { MODULE_TYPE_EXECUTOR, MODULE_TYPE_VALIDATOR } from "modulekit/external/ERC7579.sol";
+import {
+    MODULE_TYPE_EXECUTOR,
+    MODULE_TYPE_VALIDATOR
+} from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 
 contract EmailRecoveryModule_isModuleType_Test is EmailRecoveryModuleBase {
     using ModuleKitHelpers for *;

--- a/test/unit/modules/EmailRecoveryModule/name.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/name.t.sol
@@ -8,7 +8,7 @@ contract EmailRecoveryModule_name_Test is EmailRecoveryModuleBase {
         super.setUp();
     }
 
-    function test_Name_ReturnsName() public {
+    function test_Name_ReturnsName() public view {
         string memory expectedName = "ZKEmail.EmailRecoveryModule";
         string memory actualName = emailRecoveryModule.name();
         assertEq(actualName, expectedName, "Module name should match expected value");

--- a/test/unit/modules/EmailRecoveryModule/onInstall.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/onInstall.t.sol
@@ -2,7 +2,10 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR, MODULE_TYPE_VALIDATOR } from "modulekit/external/ERC7579.sol";
+import {
+    MODULE_TYPE_EXECUTOR,
+    MODULE_TYPE_VALIDATOR
+} from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { EmailRecoveryModule } from "src/modules/EmailRecoveryModule.sol";
 
 import { EmailRecoveryModuleBase } from "./EmailRecoveryModuleBase.t.sol";

--- a/test/unit/modules/EmailRecoveryModule/onUninstall.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/onUninstall.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { SentinelListHelper } from "sentinellist/SentinelListHelper.sol";
 import { EmailRecoveryModuleBase } from "./EmailRecoveryModuleBase.t.sol";
 

--- a/test/unit/modules/EmailRecoveryModule/version.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/version.t.sol
@@ -8,7 +8,7 @@ contract EmailRecoveryModule_version_Test is EmailRecoveryModuleBase {
         super.setUp();
     }
 
-    function test_Version_ReturnsVersion() public {
+    function test_Version_ReturnsVersion() public view {
         string memory expectedVersion = "1.0.0";
         string memory actualVersion = emailRecoveryModule.version();
         assertEq(actualVersion, expectedVersion, "Module version should match expected value");

--- a/test/unit/modules/UniversalEmailRecoveryModule/allowValidatorRecovery.t.sol
+++ b/test/unit/modules/UniversalEmailRecoveryModule/allowValidatorRecovery.t.sol
@@ -2,7 +2,10 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR, MODULE_TYPE_VALIDATOR } from "modulekit/external/ERC7579.sol";
+import {
+    MODULE_TYPE_EXECUTOR,
+    MODULE_TYPE_VALIDATOR
+} from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { IModule } from "erc7579/interfaces/IERC7579Module.sol";
 import { ISafe } from "src/interfaces/ISafe.sol";
 import { SentinelListLib } from "sentinellist/SentinelList.sol";

--- a/test/unit/modules/UniversalEmailRecoveryModule/canStartRecoveryRequest.t.sol
+++ b/test/unit/modules/UniversalEmailRecoveryModule/canStartRecoveryRequest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { UnitBase } from "../../UnitBase.t.sol";
 import { IGuardianManager } from "src/interfaces/IGuardianManager.sol";
 

--- a/test/unit/modules/UniversalEmailRecoveryModule/disallowValidatorRecovery.t.sol
+++ b/test/unit/modules/UniversalEmailRecoveryModule/disallowValidatorRecovery.t.sol
@@ -2,7 +2,10 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_VALIDATOR, MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import {
+    MODULE_TYPE_VALIDATOR,
+    MODULE_TYPE_EXECUTOR
+} from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { SentinelListLib } from "sentinellist/SentinelList.sol";
 import { SentinelListHelper } from "sentinellist/SentinelListHelper.sol";
 import { OwnableValidator } from "src/test/OwnableValidator.sol";

--- a/test/unit/modules/UniversalEmailRecoveryModule/getAllowedSelectors.t.sol
+++ b/test/unit/modules/UniversalEmailRecoveryModule/getAllowedSelectors.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_VALIDATOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_VALIDATOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { OwnableValidator } from "src/test/OwnableValidator.sol";
 import { UnitBase } from "../../UnitBase.t.sol";
 

--- a/test/unit/modules/UniversalEmailRecoveryModule/getAllowedValidators.t.sol
+++ b/test/unit/modules/UniversalEmailRecoveryModule/getAllowedValidators.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_VALIDATOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_VALIDATOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { SentinelListHelper } from "sentinellist/SentinelListHelper.sol";
 import { OwnableValidator } from "src/test/OwnableValidator.sol";
 import { UnitBase } from "../../UnitBase.t.sol";

--- a/test/unit/modules/UniversalEmailRecoveryModule/isInitialized.t.sol
+++ b/test/unit/modules/UniversalEmailRecoveryModule/isInitialized.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
 import { UnitBase } from "../../UnitBase.t.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 
 contract UniversalEmailRecoveryModule_isInitialized_Test is UnitBase {
     using ModuleKitHelpers for *;

--- a/test/unit/modules/UniversalEmailRecoveryModule/isModuleType.t.sol
+++ b/test/unit/modules/UniversalEmailRecoveryModule/isModuleType.t.sol
@@ -2,14 +2,17 @@
 pragma solidity ^0.8.25;
 
 import { UnitBase } from "../../UnitBase.t.sol";
-import { MODULE_TYPE_EXECUTOR, MODULE_TYPE_VALIDATOR } from "modulekit/external/ERC7579.sol";
+import {
+    MODULE_TYPE_EXECUTOR,
+    MODULE_TYPE_VALIDATOR
+} from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 
 contract UniversalEmailRecoveryModule_isModuleType_Test is UnitBase {
     function setUp() public override {
         super.setUp();
     }
 
-    function test_IsModuleType_ReturnsModuleType() public {
+    function test_IsModuleType_ReturnsModuleType() public view {
         // Verify that the module type is correct
         bool isExecutor = emailRecoveryModule.isModuleType(MODULE_TYPE_EXECUTOR);
         assertTrue(isExecutor, "Should be an executor module");

--- a/test/unit/modules/UniversalEmailRecoveryModule/onInstall.t.sol
+++ b/test/unit/modules/UniversalEmailRecoveryModule/onInstall.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { UniversalEmailRecoveryModule } from "src/modules/UniversalEmailRecoveryModule.sol";
 
 import { UnitBase } from "../../UnitBase.t.sol";

--- a/test/unit/modules/UniversalEmailRecoveryModule/onUninstall.t.sol
+++ b/test/unit/modules/UniversalEmailRecoveryModule/onUninstall.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-import { MODULE_TYPE_EXECUTOR } from "modulekit/external/ERC7579.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { SentinelListHelper } from "sentinellist/SentinelListHelper.sol";
 import { UnitBase } from "../../UnitBase.t.sol";
 

--- a/test/unit/modules/UniversalEmailRecoveryModule/version.t.sol
+++ b/test/unit/modules/UniversalEmailRecoveryModule/version.t.sol
@@ -8,7 +8,7 @@ contract UniversalEmailRecoveryModule_version_Test is UnitBase {
         super.setUp();
     }
 
-    function test_Version_ReturnsVersion() public {
+    function test_Version_ReturnsVersion() public view {
         string memory expectedVersion = "1.0.0";
         string memory actualVersion = emailRecoveryModule.version();
         assertEq(actualVersion, expectedVersion, "Module version should match expected value");


### PR DESCRIPTION
* Uses latest verifier from email-tx-builder
* Also updated modulekit version, which meant:
  * Making some changes to get everything to compile
  * `@safe-global/safe-contracts` needed to be installed manually
  * Could remove pinned erc7579 ref implementation version