### PR TITLE
feat: add recovery module with tests

### DIFF
--- a/src/SimpleGuardianManager.sol
+++ b/src/SimpleGuardianManager.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.12;
+
+contract SimpleGuardianManager {
+    struct GuardianConfig {
+        address[] guardians;
+        mapping(address => uint256) weights;
+        uint256 threshold;
+    }
+
+    struct RecoverySession {
+        address[] proofSubmitters;
+        bytes[] proofs;
+        uint256 timestamp;
+        bool active;
+    }
+
+    mapping(address => GuardianConfig) public guardianConfigs;
+    mapping(address => mapping(uint256 => RecoverySession)) private recoverySessions;
+
+    uint256 public constant PROOF_VALIDITY_PERIOD = 3 days;
+
+    event GuardiansUpdated(address indexed account, address[] guardians, uint256 threshold);
+    event GuardianWeightUpdated(address indexed account, address guardian, uint256 weight);
+    event GuardiansDeleted(address indexed account);
+    event RecoveryInitiated(address indexed account, uint256 timestamp);
+    event ProofSubmitted(address indexed account, address indexed guardian, uint256 timestamp);
+
+    modifier onlyValidThreshold(uint256 threshold) {
+        require(threshold > 0 , "Invalid threshold");
+        _;
+    }
+
+    modifier onlyGuardian(address account) {
+        bool isGuardian = false;
+        for (uint256 i = 0; i < guardianConfigs[account].guardians.length; i++) {
+            if (guardianConfigs[account].guardians[i] == msg.sender) {
+                isGuardian = true;
+                break;
+            }
+        }
+
+        require(isGuardian, "Not a guardian");
+        _;
+    }
+
+    function setGuardians(address account, address[] calldata guardians, uint256 threshold) 
+        external 
+        onlyValidThreshold(threshold) 
+    {
+        require(guardians.length > 0, "Guardians required");
+        
+        GuardianConfig storage config = guardianConfigs[account];
+        
+        delete config.guardians;
+        for (uint256 i = 0; i < guardians.length; i++) {
+            config.guardians.push(guardians[i]);
+            config.weights[guardians[i]] = 1;
+        }
+        config.threshold = threshold;
+
+        emit GuardiansUpdated(account, guardians, threshold);
+    }
+
+    function updateGuardianWeight(address account, address guardian, uint256 weight) external {
+        require(guardianConfigs[account].weights[guardian] != 0, "Guardian not found");
+        require(weight > 0, "Weight must be greater than zero");
+        
+        guardianConfigs[account].weights[guardian] = weight;
+
+        emit GuardianWeightUpdated(account, guardian, weight);
+    }
+
+    function deleteGuardians(address account) external {
+        delete guardianConfigs[account];
+        emit GuardiansDeleted(account);
+    }
+
+    function initiateRecovery(address account) external returns (uint256) {
+        uint256 timestamp = block.timestamp;
+        RecoverySession storage session = recoverySessions[account][timestamp];
+        session.timestamp = timestamp;
+        session.active = true;
+        emit RecoveryInitiated(account, timestamp);
+        return timestamp;
+    }
+
+    function submitProof(address account, uint256 timestamp, bytes calldata proof) external onlyGuardian(account) {
+        require(recoverySessions[account][timestamp].active, "No active recovery session");
+        require(block.timestamp <= timestamp + PROOF_VALIDITY_PERIOD, "Proof expired");
+        
+        recoverySessions[account][timestamp].proofSubmitters.push(msg.sender);
+        recoverySessions[account][timestamp].proofs.push(proof);
+        
+        emit ProofSubmitted(account, msg.sender, timestamp);
+    }
+
+    function hasThresholdBeenMet(address account, uint256 timestamp) external view returns (bool) {
+        return recoverySessions[account][timestamp].proofSubmitters.length >= guardianConfigs[account].threshold;
+    }
+
+    function getGuardians(address account) external view returns (address[] memory, uint256) {
+        GuardianConfig storage config = guardianConfigs[account];
+        return (config.guardians, config.threshold);
+    }
+
+    function getGuardianWeight(address account, address guardian) external view returns (uint256) {
+        return guardianConfigs[account].weights[guardian];
+    }
+
+    function getSubmittedProofs(address account, uint256 timestamp) 
+    external view returns (address[] memory, bytes[] memory) {
+        RecoverySession storage session = recoverySessions[account][timestamp];
+        return (session.proofSubmitters, session.proofs);
+    }
+
+    function setRecoveryCompleted(address account, uint256 timestamp) external onlyGuardian(account) {
+        require(recoverySessions[account][timestamp].active, "No active recovery session");
+        recoverySessions[account][timestamp].active = false;
+    }
+}

--- a/src/modules/SimpleRecoveryModule.sol
+++ b/src/modules/SimpleRecoveryModule.sol
@@ -1,0 +1,186 @@
+pragma solidity ^0.8.12;
+
+import { ERC7579ExecutorBase } from "@rhinestone/modulekit/src/Modules.sol";
+import { IERC7579Account } from "erc7579/interfaces/IERC7579Account.sol";
+import { SimpleGuardianManager } from "src/SimpleGuardianManager.sol";
+import { SignatureVerifier } from "src/verifiers/SignatureVerifier.sol";
+import { MockGroth16Verifier } from "src/test/MockGroth16Verifier.sol";
+import { EmailProof } from "@zk-email/ether-email-auth-contracts/src/interfaces/IVerifier.sol";
+
+contract SimpleRecoveryModule is ERC7579ExecutorBase {
+    struct RecoveryConfig {
+        bool activeRecovery;
+        address manager;
+        address verifiers;
+    }
+
+    mapping(address => RecoveryConfig) public recoveryConfigs;
+
+    event RecoveryInitiated(address indexed account, uint256 timestamp);
+
+    address public validator;
+
+    SignatureVerifier public signatureVerifier;
+    MockGroth16Verifier public groth16Verifier;
+
+    constructor(address _validator, address _signatureVerifier, address _groth16Verifier) {
+        validator = _validator;
+        signatureVerifier = SignatureVerifier(_signatureVerifier);
+        groth16Verifier = MockGroth16Verifier(_groth16Verifier);
+    }
+
+    function isRecoveryActive(address account) public view returns (bool) {
+        return recoveryConfigs[account].activeRecovery;
+    }
+
+    function initiateRecovery(address account) public {
+        require(!recoveryConfigs[account].activeRecovery, "Recovery is active");
+
+        SimpleGuardianManager guardianManager =
+            SimpleGuardianManager(recoveryConfigs[account].manager);
+
+        recoveryConfigs[account].activeRecovery = true;
+
+        uint256 recoveryId = guardianManager.initiateRecovery(account);
+
+        emit RecoveryInitiated(account, block.timestamp);
+    }
+
+    function recover(address account, bytes calldata recoveryData, uint256 recoveryId) public {
+        (, bytes memory recoveryCalldata) = abi.decode(recoveryData, (address, bytes));
+
+        require(recoveryConfigs[account].activeRecovery, "Recovery is not active");
+
+        SimpleGuardianManager guardianManager =
+            SimpleGuardianManager(recoveryConfigs[account].manager);
+
+        require(
+            guardianManager.hasThresholdBeenMet(account, recoveryId), "Recovery threshold not met"
+        );
+
+        (address[] memory submitters, bytes[] memory proofs) =
+            guardianManager.getSubmittedProofs(account, recoveryId);
+
+        for (uint256 i = 0; i < proofs.length; i++) {
+            require(proofs[i].length > 0, "Proof cannot be empty");
+
+            (bytes1 proofType, bytes memory proof) = abi.decode(proofs[i], (bytes1, bytes));
+
+            if (proofType == bytes1(0x00)) {
+                (
+                    string memory domainName,
+                    bytes32 publicKeyHash,
+                    uint256 timestamp,
+                    string memory maskedCommand,
+                    bytes32 emailNullifier,
+                    bytes32 accountSalt,
+                    bool isCodeExist,
+                    bytes memory proof2
+                ) = abi.decode(
+                    proof, (string, bytes32, uint256, string, bytes32, bytes32, bool, bytes)
+                );
+
+                EmailProof memory emailProof2 = EmailProof(
+                    domainName,
+                    publicKeyHash,
+                    timestamp,
+                    maskedCommand,
+                    emailNullifier,
+                    accountSalt,
+                    isCodeExist,
+                    proof2
+                );
+
+                require(groth16Verifier.verifyEmailProof(emailProof2), "Invalid email proof");
+            } else if (proofType == bytes1(0x01)) {
+                (address signer, bytes32 messageHash, bytes memory signature) =
+                    abi.decode(proof, (address, bytes32, bytes));
+
+                require(
+                    signatureVerifier.verifySignature(signer, messageHash, signature),
+                    "Invalid signature"
+                );
+            } else {
+                revert("Invalid proof type");
+            }
+        }
+
+        _execute({ account: account, to: validator, value: 0, data: recoveryCalldata });
+
+        recoveryConfigs[account].activeRecovery = false;
+    }
+
+    /**
+     * @dev Helper function to slice bytes array.
+     */
+    function sliceBytes(
+        bytes memory data,
+        uint256 start,
+        uint256 end
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        require(end > start && end <= data.length, "Invalid slice range");
+
+        bytes memory result = new bytes(end - start);
+        for (uint256 i = start; i < end; i++) {
+            result[i - start] = data[i];
+        }
+        return result;
+    }
+
+    function isInitialized(address account) external view returns (bool) {
+        return recoveryConfigs[account].manager != address(0);
+    }
+
+    /**
+     * @notice Initializes the module with the guardianManager address, verifier addresses, and a
+     * validation call
+     * @dev This method sets up the recovery configuration mapping and ensures manager call succeeds
+     * @param data Encoded data containing guardianManager, verifiers, and managerCallData
+     */
+    function onInstall(bytes calldata data) external {
+        if (data.length == 0) revert();
+
+        (bytes memory managerCallData, address guardianManager, address verifier) =
+            abi.decode(data, (bytes, address, address));
+
+        (bool success,) = guardianManager.call(managerCallData);
+        if (!success) revert();
+
+        if (
+            !IERC7579Account(msg.sender).isModuleInstalled(
+                TYPE_VALIDATOR, validator, managerCallData
+            )
+        ) {
+            revert();
+        }
+
+        recoveryConfigs[msg.sender] =
+            RecoveryConfig({ activeRecovery: false, manager: guardianManager, verifiers: verifier });
+    }
+
+    function onUninstall(bytes calldata /* data */ ) external {
+        delete recoveryConfigs[msg.sender];
+    }
+
+    function updateRecoveryConfig(address guardianManager, address verifier) external {
+        require(!recoveryConfigs[msg.sender].activeRecovery, "Recovery is active");
+        recoveryConfigs[msg.sender].manager = guardianManager;
+        recoveryConfigs[msg.sender].verifiers = verifier;
+    }
+
+    function name() external pure returns (string memory) {
+        return "ZKEmail.SimpleRecoveryModule";
+    }
+
+    function version() external pure returns (string memory) {
+        return "1.0.1";
+    }
+
+    function isModuleType(uint256 typeID) external pure returns (bool) {
+        return typeID == TYPE_EXECUTOR;
+    }
+}

--- a/src/verifiers/SignatureVerifier.sol
+++ b/src/verifiers/SignatureVerifier.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.12;
+
+contract SignatureVerifier {
+    
+    function verifySignature(
+        address signer,
+        bytes32 messageHash,
+        bytes memory signature
+    ) public pure returns (bool) {
+        require(signer != address(0), "Invalid signer address");
+        
+        
+        return recoverSigner(messageHash, signature) == signer;
+    }
+    
+    
+    function recoverSigner(bytes32 ethSignedMessageHash, bytes memory signature) public pure returns (address) {
+        require(signature.length == 65, "Invalid signature length");
+        
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        
+        assembly {
+            r := mload(add(signature, 32))
+            s := mload(add(signature, 64))
+            v := byte(0, mload(add(signature, 96)))
+        }
+        
+        require(v == 27 || v == 28, "Invalid signature version");
+        
+        return ecrecover(ethSignedMessageHash, v, r, s);
+    }
+}

--- a/test/integration/OwnableValidatorRecovery/SimpleRecoveryModule/SimpleRecoveryModule.t.sol
+++ b/test/integration/OwnableValidatorRecovery/SimpleRecoveryModule/SimpleRecoveryModule.t.sol
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
+import {
+    MODULE_TYPE_EXECUTOR,
+    MODULE_TYPE_VALIDATOR
+} from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { AccountHidingRecoveryCommandHandler } from
+    "src/handlers/AccountHidingRecoveryCommandHandler.sol";
+import { EmailRecoveryFactory } from "src/factories/EmailRecoveryFactory.sol";
+import { EmailRecoveryModule } from "src/modules/EmailRecoveryModule.sol";
+import { BaseTest, CommandHandlerType } from "../../../Base.t.sol";
+import { SimpleRecoveryModule } from "src/modules/SimpleRecoveryModule.sol";
+import { SimpleGuardianManager } from "src/SimpleGuardianManager.sol";
+import { SignatureVerifier } from "src/verifiers/SignatureVerifier.sol";
+import { console } from "forge-std/console.sol";
+import { EmailProof } from "@zk-email/ether-email-auth-contracts/src/interfaces/IVerifier.sol";
+import { Verifier } from "@zk-email/ether-email-auth-contracts/src/utils/Verifier.sol";
+import { CommandUtils } from "@zk-email/ether-email-auth-contracts/src/libraries/CommandUtils.sol";
+import { Groth16Verifier } from "@zk-email/ether-email-auth-contracts/src/utils/Groth16Verifier.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { MockGroth16Verifier } from "src/test/MockGroth16Verifier.sol";
+
+contract SimpleRecoveryModule_Test is BaseTest {
+    using ModuleKitHelpers for *;
+    using Strings for uint256;
+    using Strings for address;
+
+    EmailRecoveryFactory public emailRecoveryFactory;
+    address public commandHandlerAddress;
+    EmailRecoveryModule public emailRecoveryModule;
+
+    address public emailRecoveryModuleAddress;
+
+    address public simpleRecoveryModuleAddress;
+
+    address public simpleGuardianManagerAddress;
+
+    address public signatureVerifierAddress;
+
+    address public groth16verifier;
+
+    bytes public recoveryData1;
+
+    bytes32 public recoveryDataHash1;
+
+    address[] guardians;
+
+    uint256 public recoveryId;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        signatureVerifierAddress = address(new SignatureVerifier());
+        groth16verifier = address(new MockGroth16Verifier());
+
+        simpleRecoveryModuleAddress = address(
+            new SimpleRecoveryModule(validatorAddress, signatureVerifierAddress, groth16verifier)
+        );
+
+        simpleGuardianManagerAddress = address(new SimpleGuardianManager());
+
+        recoveryId = block.timestamp;
+
+        bytes memory changeOwnerCalldata1 = abi.encodeWithSelector(functionSelector, newOwner1);
+
+        recoveryData1 = abi.encode(validatorAddress, changeOwnerCalldata1);
+
+        recoveryDataHash1 = keccak256(recoveryData1);
+
+        guardians.push(owner2);
+        guardians.push(owner3);
+
+        bytes memory setGuardiansCalldata = abi.encodeWithSignature(
+            "setGuardians(address,address[],uint256)", instance1.account, guardians, 1
+        );
+
+        bytes memory recoveryModuleInstallData1 =
+            abi.encode(setGuardiansCalldata, simpleGuardianManagerAddress, owner2);
+
+        // Install modules for account 1
+        instance1.installModule({
+            moduleTypeId: MODULE_TYPE_VALIDATOR,
+            module: validatorAddress,
+            data: abi.encode(owner1)
+        });
+
+        instance1.installModule({
+            moduleTypeId: MODULE_TYPE_EXECUTOR,
+            module: simpleRecoveryModuleAddress,
+            data: recoveryModuleInstallData1
+        });
+    }
+
+    function test_RecoverByEmail() public {
+        uint256 currentTime = block.timestamp;
+
+        string memory accountString = CommandUtils.addressToChecksumHexString(instance1.account);
+        string memory oldOwnerString = CommandUtils.addressToChecksumHexString(owner1);
+        string memory newOwnerString = CommandUtils.addressToChecksumHexString(newOwner1);
+
+        string memory command =
+            "Recover account 0xF4F7b3D8e43a41833774CD6d962D10282f806017 from old owner 0xCe9A87013DB006Dde79E7382bf48D45bF891e90D to new owner 0x63aaF092604406C03E5B36ca1bEc1CDDF4a5Fa9d";
+        bytes32 nullifier = generateNewNullifier();
+        bytes32 accountSalt1 = keccak256(abi.encode("account salt 3"));
+
+        EmailProof memory emailProof = generateMockEmailProof(command, nullifier, accountSalt3);
+
+        MockGroth16Verifier groth16Verifier = MockGroth16Verifier(groth16verifier);
+
+        bytes memory emailProofInBytes = abi.encode(
+            emailProof.domainName,
+            emailProof.publicKeyHash,
+            emailProof.timestamp,
+            emailProof.maskedCommand,
+            emailProof.emailNullifier,
+            emailProof.accountSalt,
+            emailProof.isCodeExist,
+            emailProof.proof
+        );
+
+        bytes memory markedProof = abi.encode(bytes1(0x00), emailProofInBytes);
+
+        (bytes1 firstByte, bytes memory proof) = abi.decode(markedProof, (bytes1, bytes));
+
+        assert(firstByte == bytes1(0x00));
+
+        (
+            string memory domainName,
+            bytes32 publicKeyHash,
+            uint256 timestamp,
+            string memory maskedCommand,
+            bytes32 emailNullifier,
+            bytes32 accountSalt,
+            bool isCodeExist,
+            bytes memory proof2
+        ) = abi.decode(proof, (string, bytes32, uint256, string, bytes32, bytes32, bool, bytes));
+
+        EmailProof memory emailProof2 = EmailProof(
+            domainName,
+            publicKeyHash,
+            timestamp,
+            maskedCommand,
+            emailNullifier,
+            accountSalt,
+            isCodeExist,
+            proof2
+        );
+
+        bool result = groth16Verifier.verifyEmailProof(emailProof2); 
+        assert(result);
+    }
+
+    function test_VerifySignature_Success() public {
+        SignatureVerifier signatureVerifier = new SignatureVerifier();
+
+        bytes32 messageHash = keccak256(abi.encodePacked("Test message"));
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(vm.createWallet("owner2"), messageHash);
+        bytes memory signature = abi.encodePacked(r, s, v); // Ensure packed encoding
+
+        address acc = signatureVerifier.recoverSigner(messageHash, signature);
+        assert(acc == owner2);
+
+        bool result = signatureVerifier.verifySignature(owner2, messageHash, signature);
+        assert(result);
+
+        bytes memory combinedProof = abi.encode(owner2, messageHash, signature);
+        bytes memory markedProof = abi.encode(bytes1(0x00), combinedProof);
+
+        (bytes1 firstByte, bytes memory proof) = abi.decode(markedProof, (bytes1, bytes));
+        assert(firstByte == bytes1(0x00));
+
+        (address signer, bytes32 messageHash2, bytes memory signature2) =
+            abi.decode(proof, (address, bytes32, bytes));
+
+        assert(signer == owner2);
+        assert(messageHash2 == messageHash);
+        assertEq(signature2, signature);
+    }
+
+    function test_RecoverAccount_With_EOA_ZKEmail() public {
+        SimpleRecoveryModule simpleRecoveryModule =
+            SimpleRecoveryModule(simpleRecoveryModuleAddress);
+        SimpleGuardianManager guardianManager = SimpleGuardianManager(simpleGuardianManagerAddress);
+
+        simpleRecoveryModule.initiateRecovery(instance1.account);
+
+        // EOA Proof
+        bytes32 messageHash = keccak256(abi.encodePacked("Test message"));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(vm.createWallet("owner2"), messageHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        bytes memory proof = abi.encode(owner2, messageHash, signature);
+        bytes memory markedProof = abi.encode(bytes1(0x01), proof);
+        vm.prank(owner2);
+        guardianManager.submitProof(instance1.account, recoveryId, markedProof);
+
+        //zkEmail Proof
+        string memory command =
+            "Recover account 0xF4F7b3D8e43a41833774CD6d962D10282f806017 from old owner 0xCe9A87013DB006Dde79E7382bf48D45bF891e90D to new owner 0x63aaF092604406C03E5B36ca1bEc1CDDF4a5Fa9d";
+        bytes32 nullifier = generateNewNullifier();
+        bytes32 accountSalt1 = keccak256(abi.encode("account salt 3"));
+        EmailProof memory emailProof = generateMockEmailProof(command, nullifier, accountSalt3);
+        bytes memory emailProofInBytes = abi.encode(
+            emailProof.domainName,
+            emailProof.publicKeyHash,
+            emailProof.timestamp,
+            emailProof.maskedCommand,
+            emailProof.emailNullifier,
+            emailProof.accountSalt,
+            emailProof.isCodeExist,
+            emailProof.proof
+        );
+
+        bytes memory markedProofEmail = abi.encode(bytes1(0x00), emailProofInBytes);
+        vm.prank(owner3);
+        guardianManager.submitProof(instance1.account, recoveryId, markedProofEmail);
+
+        simpleRecoveryModule.recover(instance1.account, recoveryData, recoveryId);
+
+        address updatedOwners = validator.owners(instance1.account);
+
+        assertEq(updatedOwners, newOwner1);
+
+        vm.prank(owner2);
+        guardianManager.setRecoveryCompleted(instance1.account, 1);
+    }
+
+    // Helper functions
+
+    function computeEmailAuthAddress(
+        address account,
+        bytes32 accountSalt
+    )
+        public
+        view
+        override
+        returns (address)
+    {
+        return emailRecoveryModule.computeEmailAuthAddress(account, accountSalt);
+    }
+
+    function deployModule(bytes memory handlerBytecode) public override {
+        emailRecoveryFactory = new EmailRecoveryFactory(address(verifier), address(emailAuthImpl));
+
+        bytes32 commandHandlerSalt = bytes32(uint256(0));
+        bytes32 recoveryModuleSalt = bytes32(uint256(0));
+        (emailRecoveryModuleAddress, commandHandlerAddress) = emailRecoveryFactory
+            .deployEmailRecoveryModule(
+            commandHandlerSalt,
+            recoveryModuleSalt,
+            handlerBytecode,
+            minimumDelay,
+            killSwitchAuthorizer,
+            address(dkimRegistry),
+            validatorAddress,
+            functionSelector
+        );
+        emailRecoveryModule = EmailRecoveryModule(emailRecoveryModuleAddress);
+
+        if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
+            AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(
+                accountAddress1
+            );
+            AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(
+                accountAddress2
+            );
+            AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(
+                accountAddress3
+            );
+        }
+    }
+
+    function setRecoveryData() public override {
+        functionSelector = bytes4(keccak256(bytes("changeOwner(address)")));
+        recoveryCalldata = abi.encodeWithSelector(functionSelector, newOwner1);
+        recoveryData = abi.encode(validatorAddress, recoveryCalldata);
+        recoveryDataHash = keccak256(recoveryData);
+    }
+}


### PR DESCRIPTION
# Modular and almost stateless ERC7579 recovery module 

## Approach
The Recovery module has been designed to increase the modularity and statelessness of the module. Keeping that in mind, the module is stripped off from the current state to be minimalistic to offload the guardian/verification related executions to external contracts, which can be set by the user or whitelisted by the module itself. This allows support for multiple verifiers without upgrading/redeploying the existing module contract.

Hence, the module is totally free of any external logic and can be used according to user's choice

## Modular and Stateless aspects
- The module doesn't acts as the guardian manager itself hence it's modular in the aspect the user can come in with any preferred guardian manager
- The proofs are transient and hence not stored in the module itself
- The verifiers are set in a modular way so that the execution of proofs are done over the external contracts, hence the module is not overloaded with verification logic
- The verifiers can be white-listed by the recovery module

## Future improvements
- Allowing more generalized calls to the guardian manager
- Add support for more verifiers
- Add verifier support for P256 verifier as well

### Running test
```
forge test --match-test test_RecoverAccount_With_EOA_ZKEmail -vvvv
```

Closes #66 