### PR TITLE
added unit tests for transaction initiater changing

### DIFF
--- a/src/modules/EmailRecoveryModule.sol
+++ b/src/modules/EmailRecoveryModule.sol
@@ -105,6 +105,9 @@ contract EmailRecoveryModule is EmailRecoveryManager, ERC7579ExecutorBase, IEmai
 
         validator = _validator;
         selector = _selector;
+
+
+        deploymentTimestamp = block.timestamp;
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModule.t.sol
+++ b/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModule.t.sol
@@ -61,7 +61,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
         assertEq(guardianStorage2.weight, uint256(2));
 
         // Time travel so that EmailAuth timestamp is valid
-        vm.warp(12 seconds);
+        vm.warp(block.timestamp + 12 seconds);
         // handle recovery request for guardian 1
         handleRecovery(
             accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
@@ -128,7 +128,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
         acceptGuardianWithAccountSalt(
             accountAddress2, guardians1[1], emailRecoveryModuleAddress, accountSalt2
         );
-        vm.warp(12 seconds);
+        vm.warp(block.timestamp + 12 seconds);
 
         EmailAuthMsg memory emailAuthMsg = getRecoveryEmailAuthMessage(
             accountAddress1, guardians1[1], recoveryDataHash1, emailRecoveryModuleAddress
@@ -217,7 +217,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
 
         acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
         acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
-        vm.warp(12 seconds);
+        vm.warp(block.timestamp + 12 seconds);
 
         EmailAuthMsg memory emailAuthMsg = getRecoveryEmailAuthMessage(
             accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
@@ -234,7 +234,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
 
         acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
         acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
-        vm.warp(12 seconds);
+        vm.warp(block.timestamp + 12 seconds);
         handleRecovery(
             accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
         );
@@ -251,7 +251,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
 
         acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
         acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
-        vm.warp(12 seconds);
+        vm.warp(block.timestamp + 12 seconds);
         handleRecovery(
             accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
         );

--- a/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -148,6 +148,10 @@ abstract contract OwnableValidatorRecovery_EmailRecoveryModule_Base is BaseTest 
         // // 5- verify that only the killSwitchAuthorizer can set the transaction initiator
         // emailRecoveryModule.setTransactionInitiator(address(this), true);
 
+        // // 6- confirm that it does not work before 6 months when the transaction initiator flag is not true
+        // // (Expect 15 tests to fail under this condition.)
+        // vm.warp(block.timestamp + 7_884_000); // 3 months
+
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(
                 accountAddress1

--- a/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -123,29 +123,30 @@ abstract contract OwnableValidatorRecovery_EmailRecoveryModule_Base is BaseTest 
         // 0- verify that existing tests have failed
         // (Expect 15 tests to fail under this condition.)
 
-        // 1- verify that setting the transaction initiator flag to true works as expected.
-        vm.startPrank(killSwitchAuthorizer);
-        emailRecoveryModule.setTransactionInitiator(address(this), true);
-        vm.stopPrank();
+        // // 1- verify that setting the transaction initiator flag to true works as expected.
+        // vm.startPrank(killSwitchAuthorizer);
+        // emailRecoveryModule.setTransactionInitiator(address(this), true);
+        // vm.stopPrank();
 
         // // 2- confirm that the functionality works correctly after 6 months has passed.
         // vm.warp(block.timestamp + 15_768_000); // 6 months
 
-        // // 3- test the scenario where the transaction initiator flag is initially set to true,
-        // then changed to false.
+        // // 3- test the scenario where the transaction initiator flag is initially set to true, then changed to false.
         // // (Expect 15 tests to fail under this condition.)
         // vm.startPrank(killSwitchAuthorizer);
         // emailRecoveryModule.setTransactionInitiator(address(this), false);
         // vm.stopPrank();
 
-        // // 4- validate the behavior when the transaction initiator flag is set to true first,
-        // then changed to false,
+        // // 4- validate the behavior when the transaction initiator flag is set to true first, then changed to false,
         // // and the contract is working after a waiting period of 6 months.
         // vm.startPrank(killSwitchAuthorizer);
         // emailRecoveryModule.setTransactionInitiator(address(this), true);
         // emailRecoveryModule.setTransactionInitiator(address(this), false);
         // vm.stopPrank();
         // vm.warp(block.timestamp + 15_768_000); // 6 months
+
+        // // 5- verify that only the killSwitchAuthorizer can set the transaction initiator
+        // emailRecoveryModule.setTransactionInitiator(address(this), true);
 
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(

--- a/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -120,6 +120,33 @@ abstract contract OwnableValidatorRecovery_EmailRecoveryModule_Base is BaseTest 
         );
         emailRecoveryModule = EmailRecoveryModule(emailRecoveryModuleAddress);
 
+        // 0- verify that existing tests have failed
+        // (Expect 15 tests to fail under this condition.)
+
+        // 1- verify that setting the transaction initiator flag to true works as expected.
+        vm.startPrank(killSwitchAuthorizer);
+        emailRecoveryModule.setTransactionInitiator(address(this), true);
+        vm.stopPrank();
+
+        // // 2- confirm that the functionality works correctly after 6 months has passed.
+        // vm.warp(block.timestamp + 15_768_000); // 6 months
+
+        // // 3- test the scenario where the transaction initiator flag is initially set to true,
+        // then changed to false.
+        // // (Expect 15 tests to fail under this condition.)
+        // vm.startPrank(killSwitchAuthorizer);
+        // emailRecoveryModule.setTransactionInitiator(address(this), false);
+        // vm.stopPrank();
+
+        // // 4- validate the behavior when the transaction initiator flag is set to true first,
+        // then changed to false,
+        // // and the contract is working after a waiting period of 6 months.
+        // vm.startPrank(killSwitchAuthorizer);
+        // emailRecoveryModule.setTransactionInitiator(address(this), true);
+        // emailRecoveryModule.setTransactionInitiator(address(this), false);
+        // vm.stopPrank();
+        // vm.warp(block.timestamp + 15_768_000); // 6 months
+
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(
                 accountAddress1

--- a/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -100,6 +100,9 @@ abstract contract EmailRecoveryModuleBase is BaseTest {
         // vm.stopPrank();
         // vm.warp(block.timestamp + 15_768_000); // 6 months
 
+        // // 5- verify that only the killSwitchAuthorizer can set the transaction initiator
+        // emailRecoveryModule.setTransactionInitiator(address(this), true);
+
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(
                 accountAddress1

--- a/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -75,6 +75,31 @@ abstract contract EmailRecoveryModuleBase is BaseTest {
         );
         emailRecoveryModuleAddress = address(emailRecoveryModule);
 
+        // 0- verify that existing tests have failed
+        // (Expect 15 tests to fail under this condition.)
+
+        // // 1- verify that setting the transaction initiator flag to true works as expected.
+        // vm.startPrank(killSwitchAuthorizer);
+        // emailRecoveryModule.setTransactionInitiator(address(this), true);
+        // vm.stopPrank();
+
+        // // 2- confirm that the functionality works correctly after 6 months has passed.
+        // vm.warp(block.timestamp + 15_768_000); // 6 months
+
+        // // 3- test the scenario where the transaction initiator flag is initially set to true, then changed to false.
+        // // (Expect 15 tests to fail under this condition.)
+        // vm.startPrank(killSwitchAuthorizer);
+        // emailRecoveryModule.setTransactionInitiator(address(this), false);
+        // vm.stopPrank();
+
+        // // 4- validate the behavior when the transaction initiator flag is set to true first, then changed to false,
+        // // and the contract is working after a waiting period of 6 months.
+        // vm.startPrank(killSwitchAuthorizer);
+        // emailRecoveryModule.setTransactionInitiator(address(this), true);
+        // emailRecoveryModule.setTransactionInitiator(address(this), false);
+        // vm.stopPrank();
+        // vm.warp(block.timestamp + 15_768_000); // 6 months
+
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(
                 accountAddress1

--- a/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -103,6 +103,10 @@ abstract contract EmailRecoveryModuleBase is BaseTest {
         // // 5- verify that only the killSwitchAuthorizer can set the transaction initiator
         // emailRecoveryModule.setTransactionInitiator(address(this), true);
 
+        // // 6- confirm that it does not work before 6 months when the transaction initiator flag is not true
+        // // (Expect 15 tests to fail under this condition.)
+        // vm.warp(block.timestamp + 7_884_000); // 3 months
+
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(
                 accountAddress1


### PR DESCRIPTION
# WHAT

added the 'transactionInitiator' change to the EmailRecoveryModule contract
added unit tests for changes.

# TEST
To test the changes, please uncomment the commented lines in the test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol (lines 123-149) and test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol (lines 78-102) files. Don't forget to comment out the previous one each time.

0- No changes were made to the old existing tests. We can see the failed tests along with the changes made to the Email Recovery Module contract. (Expect 15 tests to fail under this condition.)

1- After deploying the EmailRecoveryModule, assign the address that will call the acceptGuardian and processRecovery functions as the transactionInitiator. (All tests must be passed successfully)

2- Verify that everyone can initiate transactions after 6 months, even if no transactionInitiator is assigned. (All tests must be passed successfully)

3- Verify that the setTransactionInitiator function works as expected. (Expect 15 tests to fail under this condition.)

4- Validate the behavior when the transaction initiator flag is set to true first, then changed to false, and the contract is working after a waiting period of 6 months. (All tests must be passed successfully)

5- Verify that only the killSwitchAuthorizer can set the transaction initiator. (The setup phase of the tests must be failed.)

-- New --

6- Verify that it does not work before 6 months when the transaction initiator flag is not true. (Expect 15 tests to fail under this condition.)