### PR TITLE
Add test cases for setTransactionInitiator

### DIFF
--- a/.github/workflows/forge-build.yaml
+++ b/.github/workflows/forge-build.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install Foundry"
-        uses: "foundry-rs/foundry-toolchain@v1.2.0"
+        uses: "foundry-rs/foundry-toolchain@v1.3.1"
 
       - name: "Install NodeJS"
         uses: actions/setup-node@v4

--- a/.github/workflows/forge-test-multi-account.yaml
+++ b/.github/workflows/forge-test-multi-account.yaml
@@ -80,7 +80,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install Foundry"
-        uses: "foundry-rs/foundry-toolchain@v1.2.0"
+        uses: "foundry-rs/foundry-toolchain@v1.3.1"
 
       - name: "Install NodeJS"
         uses: actions/setup-node@v4

--- a/.github/workflows/forge-test-simulate.yaml
+++ b/.github/workflows/forge-test-simulate.yaml
@@ -81,7 +81,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install Foundry"
-        uses: "foundry-rs/foundry-toolchain@v1.2.0"
+        uses: "foundry-rs/foundry-toolchain@v1.3.1"
 
       - name: "Install NodeJS"
         uses: actions/setup-node@v4

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,7 +17,6 @@ ignored_warnings_from = [
 threads = 1
 gas_limit = "18446744073709551615"
 memory_limit = 1844674407370955161
-allow_internal_expect_revert = true
 
 [rpc_endpoints]
 sepolia = "${BASE_SEPOLIA_RPC_URL}"

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,6 +17,8 @@ ignored_warnings_from = [
 threads = 1
 gas_limit = "18446744073709551615"
 memory_limit = 1844674407370955161
+allow_internal_expect_revert = true
+
 [rpc_endpoints]
 sepolia = "${BASE_SEPOLIA_RPC_URL}"
 

--- a/src/modules/EmailRecoveryModule.sol
+++ b/src/modules/EmailRecoveryModule.sol
@@ -256,7 +256,6 @@ contract EmailRecoveryModule is EmailRecoveryManager, ERC7579ExecutorBase, IEmai
     )
         internal
         override(EmailRecoveryManager)
-        onlyWhenActive
         isInitiator
     {
         super.acceptGuardian(guardian, templateIdx, commandParams, nullifier);
@@ -279,7 +278,6 @@ contract EmailRecoveryModule is EmailRecoveryManager, ERC7579ExecutorBase, IEmai
     )
         internal
         override(EmailRecoveryManager)
-        onlyWhenActive
         isInitiator
     {
         super.processRecovery(guardian, templateIdx, commandParams, nullifier);

--- a/src/modules/EmailRecoveryModule.sol
+++ b/src/modules/EmailRecoveryModule.sol
@@ -105,6 +105,7 @@ contract EmailRecoveryModule is EmailRecoveryManager, ERC7579ExecutorBase, IEmai
 
         validator = _validator;
         selector = _selector;
+        deploymentTimestamp = block.timestamp;
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModule.t.sol
+++ b/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModule.t.sol
@@ -12,7 +12,7 @@ import { IEmailRecoveryManager } from "src/interfaces/IEmailRecoveryManager.sol"
 import { IGuardianManager } from "src/interfaces/IGuardianManager.sol";
 import { GuardianStorage, GuardianStatus } from "src/libraries/EnumerableGuardianMap.sol";
 
-import { CommandHandlerType } from "../../../Base.t.sol";
+import { CommandHandlerType, IEmailRecoveryModule } from "../../../Base.t.sol";
 import { OwnableValidatorRecovery_EmailRecoveryModule_Base } from "./EmailRecoveryModuleBase.t.sol";
 
 contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
@@ -20,6 +20,10 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
 {
     using ModuleKitHelpers for *;
     using Strings for uint256;
+
+    address owner = vm.addr(2);
+    address approvedAccount = address(0x2);
+    address unapprovedAccount = address(0x3);
 
     // Helper function
     function executeRecoveryFlowForAccount(
@@ -392,5 +396,275 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
             module: emailRecoveryModuleAddress,
             data: abi.encode(isInstalledContext, guardians1, guardianWeights, threshold, delay, expiry)
         });
+    }
+
+    function test_RevertsWhenUnapprovedAccountCannotStartRecovery() public {
+        vm.startPrank(unapprovedAccount);
+        // Using getAcceptanceEmailAuthMessage and handleAcceptance directly instead of
+        // acceptGuardian
+        // because we need to test the revert behavior
+        EmailAuthMsg memory emailAuthMsg = getAcceptanceEmailAuthMessage(
+            accountAddress1, guardians1[0], emailRecoveryModuleAddress
+        );
+        vm.expectRevert("Only allowed accounts can call this function");
+        IEmailRecoveryModule(emailRecoveryModuleAddress).handleAcceptance(emailAuthMsg, templateIdx);
+        vm.stopPrank();
+    }
+
+    function test_CanStartRecoveryAfter6Months() public {
+        vm.warp(emailRecoveryModule.deploymentTimestamp() + 6 * 30 days);
+        vm.startPrank(unapprovedAccount);
+
+        // Accept guardian 1
+        acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
+        GuardianStorage memory guardianStorage1 =
+            emailRecoveryModule.getGuardian(accountAddress1, guardians1[0]);
+        assertEq(uint256(guardianStorage1.status), uint256(GuardianStatus.ACCEPTED));
+        assertEq(guardianStorage1.weight, uint256(1));
+
+        // Accept guardian 2
+        acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
+        GuardianStorage memory guardianStorage2 =
+            emailRecoveryModule.getGuardian(accountAddress1, guardians1[1]);
+        assertEq(uint256(guardianStorage2.status), uint256(GuardianStatus.ACCEPTED));
+        assertEq(guardianStorage2.weight, uint256(2));
+
+        // Time travel so that EmailAuth timestamp is valid
+        vm.warp(block.timestamp + 12 seconds);
+
+        // handle recovery request for guardian 1
+        handleRecovery(
+            accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
+        );
+        uint256 executeBefore = block.timestamp + expiry;
+        (
+            uint256 _executeAfter,
+            uint256 _executeBefore,
+            uint256 currentWeight,
+            bytes32 recoveryDataHash
+        ) = emailRecoveryModule.getRecoveryRequest(accountAddress1);
+        bool hasGuardian1Voted =
+            emailRecoveryModule.hasGuardianVoted(accountAddress1, guardians1[0]);
+        bool hasGuardian2Voted =
+            emailRecoveryModule.hasGuardianVoted(accountAddress1, guardians1[1]);
+        assertEq(_executeAfter, 0);
+        assertEq(_executeBefore, executeBefore);
+        assertEq(currentWeight, 1);
+        assertEq(recoveryDataHash, recoveryDataHash1);
+        assertEq(hasGuardian1Voted, true);
+        assertEq(hasGuardian2Voted, false);
+
+        // handle recovery request for guardian 2
+        uint256 executeAfter = block.timestamp + delay;
+        handleRecovery(
+            accountAddress1, guardians1[1], recoveryDataHash1, emailRecoveryModuleAddress
+        );
+        (_executeAfter, _executeBefore, currentWeight, recoveryDataHash) =
+            emailRecoveryModule.getRecoveryRequest(accountAddress1);
+        hasGuardian1Voted = emailRecoveryModule.hasGuardianVoted(accountAddress1, guardians1[0]);
+        hasGuardian2Voted = emailRecoveryModule.hasGuardianVoted(accountAddress1, guardians1[1]);
+        assertEq(_executeAfter, executeAfter);
+        assertEq(_executeBefore, executeBefore);
+        assertEq(currentWeight, 3);
+        assertEq(recoveryDataHash, recoveryDataHash1);
+        assertEq(hasGuardian1Voted, true);
+        assertEq(hasGuardian2Voted, true);
+
+        // Time travel so that the recovery delay has passed
+        vm.warp(block.timestamp + delay);
+
+        // Complete recovery
+        emailRecoveryModule.completeRecovery(accountAddress1, recoveryData1);
+
+        (_executeAfter, _executeBefore, currentWeight, recoveryDataHash) =
+            emailRecoveryModule.getRecoveryRequest(accountAddress1);
+        hasGuardian1Voted = emailRecoveryModule.hasGuardianVoted(accountAddress1, guardians1[0]);
+        hasGuardian2Voted = emailRecoveryModule.hasGuardianVoted(accountAddress1, guardians1[1]);
+        address updatedOwner = validator.owners(accountAddress1);
+
+        assertEq(_executeAfter, 0);
+        assertEq(_executeBefore, 0);
+        assertEq(currentWeight, 0);
+        assertEq(recoveryDataHash, bytes32(0));
+        assertEq(hasGuardian1Voted, false);
+        assertEq(hasGuardian2Voted, false);
+        assertEq(updatedOwner, newOwner1);
+
+        vm.stopPrank();
+    }
+
+    function test_RevokedPermissionPreventsFurtherActions() public {
+        // Set approvedAccount as the transaction initiator
+        vm.prank(owner);
+        emailRecoveryModule.setTransactionInitiator(approvedAccount, true);
+
+        // Execute Accept guardian 1 and as the approvedAccount
+        vm.prank(approvedAccount);
+        acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
+
+        // Disable the approvedAccount's permission
+        vm.prank(owner);
+        emailRecoveryModule.setTransactionInitiator(approvedAccount, false);
+
+        // Fail to execute Accept guardian 2 as the approvedAccount
+        vm.startPrank(approvedAccount);
+        // Using getAcceptanceEmailAuthMessage and handleAcceptance directly instead of
+        // acceptGuardian
+        // because we need to test the revert behavior
+        EmailAuthMsg memory emailAuthMsg = getAcceptanceEmailAuthMessage(
+            accountAddress1, guardians1[1], emailRecoveryModuleAddress
+        );
+        vm.expectRevert("Only allowed accounts can call this function");
+        IEmailRecoveryModule(emailRecoveryModuleAddress).handleAcceptance(emailAuthMsg, templateIdx);
+        vm.stopPrank();
+
+        // Enable the approvedAccount's permission
+        vm.prank(owner);
+        emailRecoveryModule.setTransactionInitiator(approvedAccount, true);
+
+        // Execute Accept guardian 2 as the approvedAccount
+        vm.prank(approvedAccount);
+        acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
+
+        // Execute handle recovery request for guardian 1 as the approvedAccount
+        vm.startPrank(approvedAccount);
+        // Time travel so that EmailAuth timestamp is valid
+        vm.warp(block.timestamp + 12 seconds);
+        handleRecovery(
+            accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
+        );
+        vm.stopPrank();
+
+        // Disable the approvedAccount's permission
+        vm.prank(owner);
+        emailRecoveryModule.setTransactionInitiator(approvedAccount, false);
+
+        // Fail to execute handle recovery request for guardian 2 as the approvedAccount
+        vm.startPrank(approvedAccount);
+        // Using getRecoveryEmailAuthMessage and handleRecovery directly instead of handleRecovery
+        // because we need to test the revert behavior
+        emailAuthMsg = getRecoveryEmailAuthMessage(
+            accountAddress1, guardians1[1], recoveryDataHash1, emailRecoveryModuleAddress
+        );
+        vm.expectRevert("Only allowed accounts can call this function");
+        IEmailRecoveryModule(emailRecoveryModuleAddress).handleRecovery(emailAuthMsg, templateIdx);
+        vm.stopPrank();
+
+        // Enable the approvedAccount's permission
+        vm.prank(owner);
+        emailRecoveryModule.setTransactionInitiator(approvedAccount, true);
+
+        // Execute handle recovery request for guardian 2 as the approvedAccount
+        vm.startPrank(approvedAccount);
+        handleRecovery(
+            accountAddress1, guardians1[1], recoveryDataHash1, emailRecoveryModuleAddress
+        );
+        vm.stopPrank();
+
+        // Time travel so that the recovery delay has passed
+        vm.warp(block.timestamp + delay);
+
+        // Complete recovery
+        emailRecoveryModule.completeRecovery(accountAddress1, recoveryData1);
+
+        (
+            uint256 _executeAfter,
+            uint256 _executeBefore,
+            uint256 currentWeight,
+            bytes32 recoveryDataHash
+        ) = emailRecoveryModule.getRecoveryRequest(accountAddress1);
+        bool hasGuardian1Voted =
+            emailRecoveryModule.hasGuardianVoted(accountAddress1, guardians1[0]);
+        bool hasGuardian2Voted =
+            emailRecoveryModule.hasGuardianVoted(accountAddress1, guardians1[1]);
+        address updatedOwner = validator.owners(accountAddress1);
+
+        assertEq(_executeAfter, 0);
+        assertEq(_executeBefore, 0);
+        assertEq(currentWeight, 0);
+        assertEq(recoveryDataHash, bytes32(0));
+        assertEq(hasGuardian1Voted, false);
+        assertEq(hasGuardian2Voted, false);
+        assertEq(updatedOwner, newOwner1);
+
+        vm.stopPrank();
+    }
+
+    function test_RevokedPermissionPreventsFurtherActions_WithNewApprovedAccount() public {
+        // Set approvedAccount as the transaction initiator
+        vm.prank(owner);
+        emailRecoveryModule.setTransactionInitiator(approvedAccount, true);
+
+        // Execute Accept guardian 1 and as the approvedAccount
+        vm.prank(approvedAccount);
+        acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
+
+        // Disable the approvedAccount's permission
+        vm.prank(owner);
+        emailRecoveryModule.setTransactionInitiator(approvedAccount, false);
+
+        // Fail to execute Accept guardian 2 as the approvedAccount
+        vm.startPrank(approvedAccount);
+        // Using getAcceptanceEmailAuthMessage and handleAcceptance directly instead of
+        // acceptGuardian
+        // because we need to test the revert behavior
+        EmailAuthMsg memory emailAuthMsg = getAcceptanceEmailAuthMessage(
+            accountAddress1, guardians1[1], emailRecoveryModuleAddress
+        );
+        vm.expectRevert("Only allowed accounts can call this function");
+        IEmailRecoveryModule(emailRecoveryModuleAddress).handleAcceptance(emailAuthMsg, templateIdx);
+        vm.stopPrank();
+
+        address aNewApprovedAccount = address(0x4);
+        // Enable the approvedAccount's permission
+        vm.prank(owner);
+        emailRecoveryModule.setTransactionInitiator(aNewApprovedAccount, true);
+
+        // Execute Accept guardian 2 as the approvedAccount
+        vm.prank(aNewApprovedAccount);
+        acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
+
+        // Time travel so that EmailAuth timestamp is valid
+        vm.warp(block.timestamp + 12 seconds);
+
+        // Execute handle recovery request for guardian 1 as the approvedAccount
+        vm.prank(aNewApprovedAccount);
+        handleRecovery(
+            accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
+        );
+
+        // Execute handle recovery request for guardian 2 as the approvedAccount
+        vm.prank(aNewApprovedAccount);
+        handleRecovery(
+            accountAddress1, guardians1[1], recoveryDataHash1, emailRecoveryModuleAddress
+        );
+
+        // Time travel so that the recovery delay has passed
+        vm.warp(block.timestamp + delay);
+
+        // Complete recovery
+        emailRecoveryModule.completeRecovery(accountAddress1, recoveryData1);
+
+        (
+            uint256 _executeAfter,
+            uint256 _executeBefore,
+            uint256 currentWeight,
+            bytes32 recoveryDataHash
+        ) = emailRecoveryModule.getRecoveryRequest(accountAddress1);
+        bool hasGuardian1Voted =
+            emailRecoveryModule.hasGuardianVoted(accountAddress1, guardians1[0]);
+        bool hasGuardian2Voted =
+            emailRecoveryModule.hasGuardianVoted(accountAddress1, guardians1[1]);
+        address updatedOwner = validator.owners(accountAddress1);
+
+        assertEq(_executeAfter, 0);
+        assertEq(_executeBefore, 0);
+        assertEq(currentWeight, 0);
+        assertEq(recoveryDataHash, bytes32(0));
+        assertEq(hasGuardian1Voted, false);
+        assertEq(hasGuardian2Voted, false);
+        assertEq(updatedOwner, newOwner1);
+
+        vm.stopPrank();
     }
 }

--- a/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModule.t.sol
+++ b/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModule.t.sol
@@ -61,7 +61,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
         assertEq(guardianStorage2.weight, uint256(2));
 
         // Time travel so that EmailAuth timestamp is valid
-        vm.warp(12 seconds);
+        vm.warp(block.timestamp + 12 seconds);
         // handle recovery request for guardian 1
         handleRecovery(
             accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
@@ -128,7 +128,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
         acceptGuardianWithAccountSalt(
             accountAddress2, guardians1[1], emailRecoveryModuleAddress, accountSalt2
         );
-        vm.warp(12 seconds);
+        vm.warp(block.timestamp + 12 seconds);
 
         EmailAuthMsg memory emailAuthMsg = getRecoveryEmailAuthMessage(
             accountAddress1, guardians1[1], recoveryDataHash1, emailRecoveryModuleAddress
@@ -217,7 +217,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
 
         acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
         acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
-        vm.warp(12 seconds);
+        vm.warp(block.timestamp + 12 seconds);
 
         EmailAuthMsg memory emailAuthMsg = getRecoveryEmailAuthMessage(
             accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
@@ -234,7 +234,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
 
         acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
         acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
-        vm.warp(12 seconds);
+        vm.warp(block.timestamp + 12 seconds);
         handleRecovery(
             accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
         );
@@ -251,7 +251,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
 
         acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
         acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
-        vm.warp(12 seconds);
+        vm.warp(block.timestamp + 12 seconds);
         handleRecovery(
             accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
         );

--- a/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModule.t.sol
+++ b/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModule.t.sol
@@ -21,7 +21,6 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
     using ModuleKitHelpers for *;
     using Strings for uint256;
 
-    address owner = vm.addr(2);
     address approvedAccount = address(0x2);
     address unapprovedAccount = address(0x3);
 
@@ -495,7 +494,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
 
     function test_RevokedPermissionPreventsFurtherActions() public {
         // Set approvedAccount as the transaction initiator
-        vm.prank(owner);
+        vm.prank(killSwitchAuthorizer);
         emailRecoveryModule.setTransactionInitiator(approvedAccount, true);
 
         // Execute Accept guardian 1 and as the approvedAccount
@@ -503,7 +502,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
         acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
 
         // Disable the approvedAccount's permission
-        vm.prank(owner);
+        vm.prank(killSwitchAuthorizer);
         emailRecoveryModule.setTransactionInitiator(approvedAccount, false);
 
         // Fail to execute Accept guardian 2 as the approvedAccount
@@ -519,7 +518,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
         vm.stopPrank();
 
         // Enable the approvedAccount's permission
-        vm.prank(owner);
+        vm.prank(killSwitchAuthorizer);
         emailRecoveryModule.setTransactionInitiator(approvedAccount, true);
 
         // Execute Accept guardian 2 as the approvedAccount
@@ -536,7 +535,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
         vm.stopPrank();
 
         // Disable the approvedAccount's permission
-        vm.prank(owner);
+        vm.prank(killSwitchAuthorizer);
         emailRecoveryModule.setTransactionInitiator(approvedAccount, false);
 
         // Fail to execute handle recovery request for guardian 2 as the approvedAccount
@@ -551,7 +550,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
         vm.stopPrank();
 
         // Enable the approvedAccount's permission
-        vm.prank(owner);
+        vm.prank(killSwitchAuthorizer);
         emailRecoveryModule.setTransactionInitiator(approvedAccount, true);
 
         // Execute handle recovery request for guardian 2 as the approvedAccount
@@ -592,7 +591,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
 
     function test_RevokedPermissionPreventsFurtherActions_WithNewApprovedAccount() public {
         // Set approvedAccount as the transaction initiator
-        vm.prank(owner);
+        vm.prank(killSwitchAuthorizer);
         emailRecoveryModule.setTransactionInitiator(approvedAccount, true);
 
         // Execute Accept guardian 1 and as the approvedAccount
@@ -600,7 +599,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
         acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
 
         // Disable the approvedAccount's permission
-        vm.prank(owner);
+        vm.prank(killSwitchAuthorizer);
         emailRecoveryModule.setTransactionInitiator(approvedAccount, false);
 
         // Fail to execute Accept guardian 2 as the approvedAccount
@@ -617,7 +616,7 @@ contract OwnableValidatorRecovery_EmailRecoveryModule_Integration_Test is
 
         address aNewApprovedAccount = address(0x4);
         // Enable the approvedAccount's permission
-        vm.prank(owner);
+        vm.prank(killSwitchAuthorizer);
         emailRecoveryModule.setTransactionInitiator(aNewApprovedAccount, true);
 
         // Execute Accept guardian 2 as the approvedAccount

--- a/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -148,6 +148,10 @@ abstract contract OwnableValidatorRecovery_EmailRecoveryModule_Base is BaseTest 
         // // 5- verify that only the killSwitchAuthorizer can set the transaction initiator
         // emailRecoveryModule.setTransactionInitiator(address(this), true);
 
+        // // 6- confirm that it does not work before 6 months when the transaction initiator flag is not true
+        // // (Expect 15 tests to fail under this condition.)
+        // vm.warp(block.timestamp + 7_884_000); // 3 months
+
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(
                 accountAddress1

--- a/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -123,29 +123,30 @@ abstract contract OwnableValidatorRecovery_EmailRecoveryModule_Base is BaseTest 
         // 0- verify that existing tests have failed
         // (Expect 15 tests to fail under this condition.)
 
-        // 1- verify that setting the transaction initiator flag to true works as expected.
-        vm.startPrank(killSwitchAuthorizer);
-        emailRecoveryModule.setTransactionInitiator(address(this), true);
-        vm.stopPrank();
+        // // 1- verify that setting the transaction initiator flag to true works as expected.
+        // vm.startPrank(killSwitchAuthorizer);
+        // emailRecoveryModule.setTransactionInitiator(address(this), true);
+        // vm.stopPrank();
 
         // // 2- confirm that the functionality works correctly after 6 months has passed.
         // vm.warp(block.timestamp + 15_768_000); // 6 months
 
-        // // 3- test the scenario where the transaction initiator flag is initially set to true,
-        // then changed to false.
+        // // 3- test the scenario where the transaction initiator flag is initially set to true, then changed to false.
         // // (Expect 15 tests to fail under this condition.)
         // vm.startPrank(killSwitchAuthorizer);
         // emailRecoveryModule.setTransactionInitiator(address(this), false);
         // vm.stopPrank();
 
-        // // 4- validate the behavior when the transaction initiator flag is set to true first,
-        // then changed to false,
+        // // 4- validate the behavior when the transaction initiator flag is set to true first, then changed to false,
         // // and the contract is working after a waiting period of 6 months.
         // vm.startPrank(killSwitchAuthorizer);
         // emailRecoveryModule.setTransactionInitiator(address(this), true);
         // emailRecoveryModule.setTransactionInitiator(address(this), false);
         // vm.stopPrank();
         // vm.warp(block.timestamp + 15_768_000); // 6 months
+
+        // // 5- verify that only the killSwitchAuthorizer can set the transaction initiator
+        // emailRecoveryModule.setTransactionInitiator(address(this), true);
 
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(

--- a/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -120,6 +120,33 @@ abstract contract OwnableValidatorRecovery_EmailRecoveryModule_Base is BaseTest 
         );
         emailRecoveryModule = EmailRecoveryModule(emailRecoveryModuleAddress);
 
+        // 0- verify that existing tests have failed
+        // (Expect 15 tests to fail under this condition.)
+
+        // 1- verify that setting the transaction initiator flag to true works as expected.
+        vm.startPrank(killSwitchAuthorizer);
+        emailRecoveryModule.setTransactionInitiator(address(this), true);
+        vm.stopPrank();
+
+        // // 2- confirm that the functionality works correctly after 6 months has passed.
+        // vm.warp(block.timestamp + 15_768_000); // 6 months
+
+        // // 3- test the scenario where the transaction initiator flag is initially set to true,
+        // then changed to false.
+        // // (Expect 15 tests to fail under this condition.)
+        // vm.startPrank(killSwitchAuthorizer);
+        // emailRecoveryModule.setTransactionInitiator(address(this), false);
+        // vm.stopPrank();
+
+        // // 4- validate the behavior when the transaction initiator flag is set to true first,
+        // then changed to false,
+        // // and the contract is working after a waiting period of 6 months.
+        // vm.startPrank(killSwitchAuthorizer);
+        // emailRecoveryModule.setTransactionInitiator(address(this), true);
+        // emailRecoveryModule.setTransactionInitiator(address(this), false);
+        // vm.stopPrank();
+        // vm.warp(block.timestamp + 15_768_000); // 6 months
+
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(
                 accountAddress1

--- a/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/integration/OwnableValidatorRecovery/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -120,37 +120,9 @@ abstract contract OwnableValidatorRecovery_EmailRecoveryModule_Base is BaseTest 
         );
         emailRecoveryModule = EmailRecoveryModule(emailRecoveryModuleAddress);
 
-        // 0- verify that existing tests have failed
-        // (Expect 15 tests to fail under this condition.)
-
-        // // 1- verify that setting the transaction initiator flag to true works as expected.
-        // vm.startPrank(killSwitchAuthorizer);
-        // emailRecoveryModule.setTransactionInitiator(address(this), true);
-        // vm.stopPrank();
-
-        // // 2- confirm that the functionality works correctly after 6 months has passed.
-        // vm.warp(block.timestamp + 15_768_000); // 6 months
-
-        // // 3- test the scenario where the transaction initiator flag is initially set to true, then changed to false.
-        // // (Expect 15 tests to fail under this condition.)
-        // vm.startPrank(killSwitchAuthorizer);
-        // emailRecoveryModule.setTransactionInitiator(address(this), false);
-        // vm.stopPrank();
-
-        // // 4- validate the behavior when the transaction initiator flag is set to true first, then changed to false,
-        // // and the contract is working after a waiting period of 6 months.
-        // vm.startPrank(killSwitchAuthorizer);
-        // emailRecoveryModule.setTransactionInitiator(address(this), true);
-        // emailRecoveryModule.setTransactionInitiator(address(this), false);
-        // vm.stopPrank();
-        // vm.warp(block.timestamp + 15_768_000); // 6 months
-
-        // // 5- verify that only the killSwitchAuthorizer can set the transaction initiator
-        // emailRecoveryModule.setTransactionInitiator(address(this), true);
-
-        // // 6- confirm that it does not work before 6 months when the transaction initiator flag is not true
-        // // (Expect 15 tests to fail under this condition.)
-        // vm.warp(block.timestamp + 7_884_000); // 3 months
+        vm.startPrank(killSwitchAuthorizer);
+        emailRecoveryModule.setTransactionInitiator(address(this), true);
+        vm.stopPrank();
 
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(

--- a/test/unit/EmailRecoveryModuleHarness.sol
+++ b/test/unit/EmailRecoveryModuleHarness.sol
@@ -47,4 +47,8 @@ contract EmailRecoveryModuleHarness is EmailRecoveryModule {
     {
         processRecovery(guardian, templateIdx, commandParams, nullifier);
     }
+
+    function exposed_getTransactionInitiator(address account) external view returns (bool) {
+        return transactionInitiators[account];
+    }
 }

--- a/test/unit/EmailRecoveryModuleHarness.sol
+++ b/test/unit/EmailRecoveryModuleHarness.sol
@@ -36,4 +36,15 @@ contract EmailRecoveryModuleHarness is EmailRecoveryModule {
     function exposed_acceptGuardian(address guardian, uint256 templateIdx, bytes[] memory commandParams, bytes32 nullifier) external {
         acceptGuardian(guardian, templateIdx, commandParams, nullifier);
     }
+
+    function exposed_processRecovery(
+        address guardian,
+        uint256 templateIdx,
+        bytes[] memory commandParams,
+        bytes32 nullifier
+    )
+        external
+    {
+        processRecovery(guardian, templateIdx, commandParams, nullifier);
+    }
 }

--- a/test/unit/EmailRecoveryModuleHarness.sol
+++ b/test/unit/EmailRecoveryModuleHarness.sol
@@ -32,4 +32,8 @@ contract EmailRecoveryModuleHarness is EmailRecoveryModule {
     function exposed_recover(address account, bytes calldata recoveryData) external {
         recover(account, recoveryData);
     }
+
+    function exposed_acceptGuardian(address guardian, uint256 templateIdx, bytes[] memory commandParams, bytes32 nullifier) external {
+        acceptGuardian(guardian, templateIdx, commandParams, nullifier);
+    }
 }

--- a/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -75,37 +75,9 @@ abstract contract EmailRecoveryModuleBase is BaseTest {
         );
         emailRecoveryModuleAddress = address(emailRecoveryModule);
 
-        // 0- verify that existing tests have failed
-        // (Expect 15 tests to fail under this condition.)
-
-        // // 1- verify that setting the transaction initiator flag to true works as expected.
-        // vm.startPrank(killSwitchAuthorizer);
-        // emailRecoveryModule.setTransactionInitiator(address(this), true);
-        // vm.stopPrank();
-
-        // // 2- confirm that the functionality works correctly after 6 months has passed.
-        // vm.warp(block.timestamp + 15_768_000); // 6 months
-
-        // // 3- test the scenario where the transaction initiator flag is initially set to true, then changed to false.
-        // // (Expect 15 tests to fail under this condition.)
-        // vm.startPrank(killSwitchAuthorizer);
-        // emailRecoveryModule.setTransactionInitiator(address(this), false);
-        // vm.stopPrank();
-
-        // // 4- validate the behavior when the transaction initiator flag is set to true first, then changed to false,
-        // // and the contract is working after a waiting period of 6 months.
-        // vm.startPrank(killSwitchAuthorizer);
-        // emailRecoveryModule.setTransactionInitiator(address(this), true);
-        // emailRecoveryModule.setTransactionInitiator(address(this), false);
-        // vm.stopPrank();
-        // vm.warp(block.timestamp + 15_768_000); // 6 months
-
-        // // 5- verify that only the killSwitchAuthorizer can set the transaction initiator
-        // emailRecoveryModule.setTransactionInitiator(address(this), true);
-
-        // // 6- confirm that it does not work before 6 months when the transaction initiator flag is not true
-        // // (Expect 15 tests to fail under this condition.)
-        // vm.warp(block.timestamp + 7_884_000); // 3 months
+        vm.startPrank(killSwitchAuthorizer);
+        emailRecoveryModule.setTransactionInitiator(address(this), true);
+        vm.stopPrank();
 
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(

--- a/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -100,6 +100,9 @@ abstract contract EmailRecoveryModuleBase is BaseTest {
         // vm.stopPrank();
         // vm.warp(block.timestamp + 15_768_000); // 6 months
 
+        // // 5- verify that only the killSwitchAuthorizer can set the transaction initiator
+        // emailRecoveryModule.setTransactionInitiator(address(this), true);
+
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(
                 accountAddress1

--- a/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -75,6 +75,31 @@ abstract contract EmailRecoveryModuleBase is BaseTest {
         );
         emailRecoveryModuleAddress = address(emailRecoveryModule);
 
+        // 0- verify that existing tests have failed
+        // (Expect 15 tests to fail under this condition.)
+
+        // // 1- verify that setting the transaction initiator flag to true works as expected.
+        // vm.startPrank(killSwitchAuthorizer);
+        // emailRecoveryModule.setTransactionInitiator(address(this), true);
+        // vm.stopPrank();
+
+        // // 2- confirm that the functionality works correctly after 6 months has passed.
+        // vm.warp(block.timestamp + 15_768_000); // 6 months
+
+        // // 3- test the scenario where the transaction initiator flag is initially set to true, then changed to false.
+        // // (Expect 15 tests to fail under this condition.)
+        // vm.startPrank(killSwitchAuthorizer);
+        // emailRecoveryModule.setTransactionInitiator(address(this), false);
+        // vm.stopPrank();
+
+        // // 4- validate the behavior when the transaction initiator flag is set to true first, then changed to false,
+        // // and the contract is working after a waiting period of 6 months.
+        // vm.startPrank(killSwitchAuthorizer);
+        // emailRecoveryModule.setTransactionInitiator(address(this), true);
+        // emailRecoveryModule.setTransactionInitiator(address(this), false);
+        // vm.stopPrank();
+        // vm.warp(block.timestamp + 15_768_000); // 6 months
+
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(
                 accountAddress1

--- a/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/EmailRecoveryModuleBase.t.sol
@@ -103,6 +103,10 @@ abstract contract EmailRecoveryModuleBase is BaseTest {
         // // 5- verify that only the killSwitchAuthorizer can set the transaction initiator
         // emailRecoveryModule.setTransactionInitiator(address(this), true);
 
+        // // 6- confirm that it does not work before 6 months when the transaction initiator flag is not true
+        // // (Expect 15 tests to fail under this condition.)
+        // vm.warp(block.timestamp + 7_884_000); // 3 months
+
         if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
             AccountHidingRecoveryCommandHandler(commandHandlerAddress).storeAccountHash(
                 accountAddress1

--- a/test/unit/modules/EmailRecoveryModule/acceptGuardian.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/acceptGuardian.t.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
+import { EmailRecoveryModuleBase } from "./EmailRecoveryModuleBase.t.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { CommandHandlerType } from "../../../Base.t.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+
+contract EmailRecoveryModule_acceptGuardian_Test is EmailRecoveryModuleBase {
+    using ModuleKitHelpers for *;
+    using Strings for uint256;
+
+    bytes[] public commandParams;
+    bytes32 public nullifier;
+
+    address owner = vm.addr(2);
+    address nonOwner = address(0x2);
+    address testAccount = address(0x3);
+
+    function setUp() public override {
+        super.setUp();
+
+        if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
+            commandParams = new bytes[](1);
+            commandParams[0] =
+                abi.encode(uint256(keccak256(abi.encodePacked(accountAddress1))).toHexString(32));
+        } else {
+            commandParams = new bytes[](1);
+            commandParams[0] = abi.encode(accountAddress1);
+        }
+
+        nullifier = keccak256(abi.encode("nullifier 1"));
+    }
+
+    function test_RevertsWhenTransactionInitiatorNotSet() public {
+        vm.startPrank(owner);
+        vm.expectRevert("Only allowed accounts can call this function");
+        emailRecoveryModule.exposed_acceptGuardian(
+            guardians1[0], templateIdx, commandParams, nullifier
+        );
+        vm.stopPrank();
+    }
+
+    function test_FailsWhenExactly6MonthsMinus1Second() public {
+        vm.warp(emailRecoveryModule.deploymentTimestamp() + 6 * 30 days - 1 seconds);
+
+        vm.startPrank(testAccount);
+        vm.expectRevert("Only allowed accounts can call this function");
+        emailRecoveryModule.exposed_acceptGuardian(
+            guardians1[0], templateIdx, commandParams, nullifier
+        );
+        vm.stopPrank();
+    }
+
+    function test_SucceedsWhenTransactionInitiatorIsSet() public {
+        vm.prank(owner);
+        emailRecoveryModule.setTransactionInitiator(testAccount, true);
+
+        vm.prank(testAccount);
+        emailRecoveryModule.exposed_acceptGuardian(
+            guardians1[0], templateIdx, commandParams, nullifier
+        );
+    }
+
+    function test_SucceedsWhenExactly6Months() public {
+        vm.warp(emailRecoveryModule.deploymentTimestamp() + 6 * 30 days);
+        emailRecoveryModule.exposed_acceptGuardian(
+            guardians1[0], templateIdx, commandParams, nullifier
+        );
+    }
+
+    function test_SucceedsWhenExactly6MonthsPlus1Second() public {
+        vm.warp(emailRecoveryModule.deploymentTimestamp() + 6 * 30 days + 1 seconds);
+        emailRecoveryModule.exposed_acceptGuardian(
+            guardians1[0], templateIdx, commandParams, nullifier
+        );
+    }
+
+    function test_SucceedsWhenZeroAddressForTransactionInitiatorIsSetToTrue() public {
+        vm.prank(owner);
+        emailRecoveryModule.setTransactionInitiator(address(0), true);
+
+        emailRecoveryModule.exposed_acceptGuardian(
+            guardians1[0], templateIdx, commandParams, nullifier
+        );
+    }
+}

--- a/test/unit/modules/EmailRecoveryModule/constructor.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/constructor.t.sol
@@ -150,5 +150,6 @@ contract EmailRecoveryModule_constructor_Test is EmailRecoveryModuleBase {
 
         assertEq(validatorAddress, emailRecoveryModule.validator());
         assertEq(functionSelector, emailRecoveryModule.selector());
+        assertEq(block.timestamp, emailRecoveryModule.deploymentTimestamp());
     }
 }

--- a/test/unit/modules/EmailRecoveryModule/processRecovery.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/processRecovery.t.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
+import { EmailRecoveryModuleBase } from "./EmailRecoveryModuleBase.t.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { CommandHandlerType } from "../../../Base.t.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+
+contract EmailRecoveryModule_processRecovery_Test is EmailRecoveryModuleBase {
+    using ModuleKitHelpers for *;
+    using Strings for uint256;
+
+    string public recoveryDataHashString;
+    bytes[] public commandParams;
+    bytes32 public nullifier;
+
+    address owner = vm.addr(2);
+    address nonOwner = address(0x2);
+    address testAccount = address(0x3);
+
+    function setUp() public override {
+        super.setUp();
+
+        if (getCommandHandlerType() == CommandHandlerType.EmailRecoveryCommandHandler) {
+            recoveryDataHashString = uint256(recoveryDataHash).toHexString(32);
+            commandParams = new bytes[](2);
+            commandParams[0] = abi.encode(accountAddress1);
+            commandParams[1] = abi.encode(recoveryDataHashString);
+        }
+        if (getCommandHandlerType() == CommandHandlerType.AccountHidingRecoveryCommandHandler) {
+            recoveryDataHashString = uint256(recoveryDataHash).toHexString(32);
+            commandParams = new bytes[](2);
+            commandParams[0] =
+                abi.encode(uint256(keccak256(abi.encodePacked(accountAddress1))).toHexString(32));
+            commandParams[1] = abi.encode(recoveryDataHashString);
+        }
+        if (getCommandHandlerType() == CommandHandlerType.SafeRecoveryCommandHandler) {
+            commandParams = new bytes[](3);
+            commandParams[0] = abi.encode(accountAddress1);
+            commandParams[1] = abi.encode(owner1);
+            commandParams[2] = abi.encode(newOwner1);
+        }
+
+        nullifier = keccak256(abi.encode("nullifier 1"));
+    }
+
+    function test_RevertsWhenTransactionInitiatorNotSet() public {
+        vm.startPrank(testAccount);
+        vm.expectRevert("Only allowed accounts can call this function");
+        emailRecoveryModule.exposed_processRecovery(
+            guardians1[0], templateIdx, commandParams, nullifier
+        );
+        vm.stopPrank();
+    }
+
+    function test_FailsWhenExactly6MonthsMinus1Second() public {
+        vm.startPrank(testAccount);
+        vm.warp(emailRecoveryModule.deploymentTimestamp() + 6 * 30 days - 1 seconds);
+        vm.expectRevert("Only allowed accounts can call this function");
+        emailRecoveryModule.exposed_processRecovery(
+            guardians1[0], templateIdx, commandParams, nullifier
+        );
+        vm.stopPrank();
+    }
+
+    function test_SucceedsWhenTransactionInitiatorIsSet() public {
+        vm.startPrank(owner);
+        emailRecoveryModule.setTransactionInitiator(testAccount, true);
+        vm.stopPrank();
+
+        acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
+        acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
+
+        vm.prank(testAccount);
+        emailRecoveryModule.exposed_processRecovery(
+            guardians1[0], templateIdx, commandParams, nullifier
+        );
+    }
+
+    function test_SucceedsWhenExactly6Months() public {
+        acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
+        acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
+
+        vm.warp(emailRecoveryModule.deploymentTimestamp() + 6 * 30 days);
+        emailRecoveryModule.exposed_processRecovery(
+            guardians1[0], templateIdx, commandParams, nullifier
+        );
+    }
+
+    function test_SucceedsWhenExactly6MonthsPlus1Second() public {
+        acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
+        acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
+
+        vm.warp(emailRecoveryModule.deploymentTimestamp() + 6 * 30 days + 1 seconds);
+        emailRecoveryModule.exposed_processRecovery(
+            guardians1[0], templateIdx, commandParams, nullifier
+        );
+    }
+
+    function test_SucceedsWhenZeroAddressForTransactionInitiatorIsSetToTrue() public {
+        vm.prank(owner);
+        emailRecoveryModule.setTransactionInitiator(address(0), true);
+
+        acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
+        acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
+
+        vm.startPrank(testAccount);
+        emailRecoveryModule.exposed_processRecovery(
+            guardians1[0], templateIdx, commandParams, nullifier
+        );
+        vm.stopPrank();
+    }
+}

--- a/test/unit/modules/EmailRecoveryModule/setTransactionInitiator.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/setTransactionInitiator.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { ModuleKitHelpers } from "modulekit/ModuleKit.sol";
+import { EmailRecoveryModuleBase } from "./EmailRecoveryModuleBase.t.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract EmailRecoveryModule_setTransactionInitiator_Test is EmailRecoveryModuleBase {
+    using ModuleKitHelpers for *;
+
+    address owner = vm.addr(2);
+    address nonOwner = address(0x2);
+    address testAccount = address(0x3);
+
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function test_RevertsIfNotOwner() public {
+        vm.prank(nonOwner);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, nonOwner)
+        );
+        emailRecoveryModule.setTransactionInitiator(owner, true);
+    }
+
+    function test_SetsNonZeroAddressToTrue() public {
+        vm.prank(owner);
+        emailRecoveryModule.setTransactionInitiator(testAccount, true);
+    }
+
+    function test_SetsNonZeroAddressToFalseAfterTrue() public {
+        vm.startPrank(owner);
+        emailRecoveryModule.setTransactionInitiator(testAccount, true);
+
+        emailRecoveryModule.setTransactionInitiator(testAccount, false);
+        vm.stopPrank();
+    }
+
+    function test_SetsZeroAddressToTrue() public {
+        vm.prank(owner);
+        emailRecoveryModule.setTransactionInitiator(address(0), true);
+    }
+
+    function test_SetsZeroAddressToFalseAfterTrue() public {
+        vm.startPrank(owner);
+        emailRecoveryModule.setTransactionInitiator(address(0), true);
+
+        emailRecoveryModule.setTransactionInitiator(address(0), false);
+        vm.stopPrank();
+    }
+}

--- a/test/unit/modules/EmailRecoveryModule/setTransactionInitiator.t.sol
+++ b/test/unit/modules/EmailRecoveryModule/setTransactionInitiator.t.sol
@@ -9,7 +9,6 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 contract EmailRecoveryModule_setTransactionInitiator_Test is EmailRecoveryModuleBase {
     using ModuleKitHelpers for *;
 
-    address owner = vm.addr(2);
     address nonOwner = address(0x2);
     address testAccount = address(0x3);
 
@@ -22,32 +21,36 @@ contract EmailRecoveryModule_setTransactionInitiator_Test is EmailRecoveryModule
         vm.expectRevert(
             abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, nonOwner)
         );
-        emailRecoveryModule.setTransactionInitiator(owner, true);
+        emailRecoveryModule.setTransactionInitiator(killSwitchAuthorizer, true);
     }
 
     function test_SetsNonZeroAddressToTrue() public {
-        vm.prank(owner);
+        vm.prank(killSwitchAuthorizer);
         emailRecoveryModule.setTransactionInitiator(testAccount, true);
+        vm.assertEq(emailRecoveryModule.exposed_getTransactionInitiator(testAccount), true);
     }
 
     function test_SetsNonZeroAddressToFalseAfterTrue() public {
-        vm.startPrank(owner);
+        vm.startPrank(killSwitchAuthorizer);
         emailRecoveryModule.setTransactionInitiator(testAccount, true);
-
+        vm.assertEq(emailRecoveryModule.exposed_getTransactionInitiator(testAccount), true);
         emailRecoveryModule.setTransactionInitiator(testAccount, false);
+        vm.assertEq(emailRecoveryModule.exposed_getTransactionInitiator(testAccount), false);
         vm.stopPrank();
     }
 
     function test_SetsZeroAddressToTrue() public {
-        vm.prank(owner);
+        vm.prank(killSwitchAuthorizer);
         emailRecoveryModule.setTransactionInitiator(address(0), true);
+        vm.assertEq(emailRecoveryModule.exposed_getTransactionInitiator(address(0)), true);
     }
 
     function test_SetsZeroAddressToFalseAfterTrue() public {
-        vm.startPrank(owner);
+        vm.startPrank(killSwitchAuthorizer);
         emailRecoveryModule.setTransactionInitiator(address(0), true);
-
+        vm.assertEq(emailRecoveryModule.exposed_getTransactionInitiator(address(0)), true);
         emailRecoveryModule.setTransactionInitiator(address(0), false);
+        vm.assertEq(emailRecoveryModule.exposed_getTransactionInitiator(address(0)), false);
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
This PR adds test cases to the following PR:
https://github.com/zkemail/email-recovery/pull/81

The tests cover the setTransactionInitiator function as comprehensively as possible, following the comments in this review:
https://github.com/zkemail/email-recovery/pull/81#pullrequestreview-2593474297

I removed the onlyWhenActive modifier from acceptGuardian and processRecovery in EmailRecoveryModule because it was applied twice. Other than that, I didn't change the implementation.

However, if you find any issues or areas for improvement, especially regarding test readability, please let me know.