### PR TITLE
fix: optimizer enabled with 200 runs for foundry

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -17,6 +17,9 @@ ignored_warnings_from = [
 threads = 1
 gas_limit = "18446744073709551615"
 memory_limit = 1844674407370955161
+optimizer=true
+optimizer_runs=200
+
 [rpc_endpoints]
 sepolia = "${BASE_SEPOLIA_RPC_URL}"
 


### PR DESCRIPTION
# Introduction 

`EmailRecoveryUniversalFactory` has runtime size of 43,480 bytes, which is over contract size limit (24,576 bytes), resulting into the deployment failure

## Solution

Enabling optimizer during deployment reduces the size to 23,758 bytes with 200 runs solves the issue

## Note

Runs can be increased to 20_000 as well to further optimize if required