### PR TITLE
feat: Jwt Guardian verifier added

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,8 +1,9 @@
 [profile.default]
 evm_version = "cancun"
 src = "src"
+test="test-new"
 out = "out"
-script = "script"
+script = "scripts"
 libs = ["node_modules", "lib"]
 fs_permissions = [
     { access = "read", path = "out-optimized" },

--- a/remappings.txt
+++ b/remappings.txt
@@ -24,3 +24,5 @@ solidity-stringutils/=node_modules/solidity-stringutils/
 @matterlabs/zksync-contracts/l2/contracts/=src/libraries/
 kernel/=node_modules/@zerodev/kernel/src/
 ExcessivelySafeCall/=node_modules/excessively-safe-call/src/
+
+src/=src/

--- a/src/JwtGuardianVerifier.sol
+++ b/src/JwtGuardianVerifier.sol
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IDKIMRegistry} from "@zk-email/contracts/DKIMRegistry.sol";
+
+import {IGuardianVerifier} from "./interfaces/IGuardianVerifier.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {IVerifier, EmailProof} from "./interfaces/IJwtVerifier.sol";
+
+/**
+ * @title JwtGuardianVerifier
+ * @notice Provides a mechanism for guardian verification using jwt token proofs
+ * @dev The underlying IGuardianVerifier provides the interface for proof verification.
+ */
+contract JwtGuardianVerifier is IGuardianVerifier, Initializable {
+    // NOTE: Temporary bypass, remove after the upgrade
+    address _owner;
+
+    bool public timestampCheckEnabled;
+    uint256 public lastTimestamp;
+
+    mapping(bytes32 emailNullifier => bool used) public usedNullifiers;
+
+    IDKIMRegistry public jwtRegistry;
+
+    IVerifier public verifier;
+
+    struct JwtData {
+        string domainName;
+        uint256 timestamp;
+        string maskedCommand;
+        bytes32 accountSalt;
+        bool isCodeExist;
+        bool isRecovery;
+    }
+
+    /// @notice Returns the address of the JWT registry contract.
+    /// @return address The address of the DKIM registry contract.
+    function jwtRegistryAddr() public view returns (address) {
+        return address(jwtRegistry);
+    }
+
+    /// @notice Returns the address of the verifier contract.
+    /// @return address The Address of the verifier contract.
+    function verifierAddr() public view returns (address) {
+        return address(verifier);
+    }
+
+    constructor() {}
+
+    //TODO: Maybe accountSalt can be passed while intializing the contract
+    /**
+     * @dev Initializes the contract with the JWT registry, verifier addresses.
+     * @notice Addresses are hardcoded for the initial implementation.
+     *
+     * @param {recoveredAccount} The address of the account to be recovered.
+     * @param {accountSalt} The salt used to derive the account address.
+     * @param {initData} The initialization data.
+     */
+    function initialize(
+        address /* recoveredAccount */,
+        bytes32 /* accountSalt */,
+        bytes calldata initData
+    ) public initializer {
+        // NOTE: Temporary bypass, remove after the upgrade
+        _owner = msg.sender;
+
+        // address _dkimRegistry = 0x3D3935B3C030893f118a84C92C66dF1B9E4169d6;
+        // address _verifier = 0x3E5f29a7cCeb30D5FCD90078430CA110c2985716;
+
+        (address _jwtRegistry, address _verifier) = abi.decode(
+            initData,
+            (address, address)
+        );
+
+        jwtRegistry = IDKIMRegistry(_jwtRegistry);
+        verifier = IVerifier(_verifier);
+
+        timestampCheckEnabled = true;
+    }
+
+    // NOTE: Temporary bypass, remove after the upgrade
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Verify the proof
+     * Recommended to use when proof verification is done on-chain or when called from another contract
+     *
+     * @notice Reverts if the proof is invalid
+     *
+     * @param recoveredAccount Account to be recovered
+     * @param proof Proof data
+     * proof.data: JwtData
+     * proof.publicInputs: [publicKeyHash, emailNullifier]
+     * proof.proof: zk-SNARK proof
+     *
+     * @return isVerified if the proof is valid
+     */
+    function verifyProofStrict(
+        address recoveredAccount,
+        ProofData memory proof
+    ) public view returns (bool) {
+        // Parse the extra data
+        JwtData memory jwtData = abi.decode(proof.data, (JwtData));
+
+        require(jwtData.isCodeExist == true, "isCodeExist is false");
+
+        EmailProof memory jwtProof = EmailProof({
+            domainName: jwtData.domainName,
+            publicKeyHash: proof.publicInputs[0],
+            timestamp: jwtData.timestamp,
+            maskedCommand: jwtData.maskedCommand,
+            emailNullifier: proof.publicInputs[1],
+            accountSalt: jwtData.accountSalt,
+            isCodeExist: jwtData.isCodeExist,
+            proof: proof.proof
+        });
+
+        // require(
+        //     jwtRegistry.isDKIMPublicKeyHashValid(
+        //         jwtProof.domainName,
+        //         jwtProof.publicKeyHash
+        //     ) == true,
+        //     "invalid dkim public key hash"
+        // );
+
+        require(
+            usedNullifiers[jwtProof.emailNullifier] == false,
+            "email nullifier already used"
+        );
+
+        // TODO: match with the accountSalt added during initialization
+        // require(
+        //     accountSalt == jwtProof.accountSalt,
+        //     "invalid account salt"
+        // );
+
+        require(
+            timestampCheckEnabled == false ||
+                jwtProof.timestamp == 0 ||
+                jwtProof.timestamp > lastTimestamp,
+            "invalid timestamp"
+        );
+
+        require(
+            bytes(jwtProof.maskedCommand).length <= verifier.getCommandBytes(),
+            "invalid masked command length"
+        );
+
+        require(
+            verifier.verifyEmailProof(jwtProof) == true,
+            "invalid email proof"
+        );
+
+        // TODO: How to handle the nullifier update
+        // usedNullifiers[jwtProof.emailNullifier] = true;
+        // if (timestampCheckEnabled && jwtProof.timestamp != 0) {
+        //     lastTimestamp = jwtProof.timestamp;
+        // }
+
+        return (true);
+    }
+
+    /**
+     * @dev Verify the proof and return the result and error message
+     * Recommended to use when proof verification is done off-chain
+     *
+     * @notice Can be used to check the proof and get the error message
+     * @notice No revert if the proof is invalid
+     *
+     * @param recoveredAccount Account to be recovered
+     * @param proof Proof data
+     * proof.data: JwtData
+     * proof.publicInputs: [publicKeyHash, emailNullifier]
+     * proof.proof: zk-SNARK proof
+     *
+     * @return isVerified if the proof is valid
+     * @return error message if the proof is invalid
+     */
+    // Lint Error: Cyclomatic complexity ( too many if else statements )
+    function verifyProof(
+        address recoveredAccount,
+        ProofData memory proof
+    ) public view returns (bool, string memory) {
+        JwtData memory jwtData = abi.decode(proof.data, (JwtData));
+
+        if (jwtData.isCodeExist == false) {
+            return (false, "isCodeExist is false");
+        }
+
+        EmailProof memory jwtProof = EmailProof({
+            domainName: jwtData.domainName,
+            publicKeyHash: proof.publicInputs[0],
+            timestamp: jwtData.timestamp,
+            maskedCommand: jwtData.maskedCommand,
+            emailNullifier: proof.publicInputs[1],
+            accountSalt: jwtData.accountSalt,
+            isCodeExist: jwtData.isCodeExist,
+            proof: proof.proof
+        });
+
+        if (
+            jwtRegistry.isDKIMPublicKeyHashValid(
+                jwtProof.domainName,
+                jwtProof.publicKeyHash
+            ) == false
+        ) {
+            return (false, "invalid dkim public key hash");
+        }
+        // require(
+        //     jwtRegistry.isDKIMPublicKeyHashValid(
+        //         jwtProof.domainName,
+        //         jwtProof.publicKeyHash
+        //     ) == true,
+        //     "invalid dkim public key hash"
+        // );
+
+        if (usedNullifiers[jwtProof.emailNullifier] == true) {
+            return (false, "email nullifier already used");
+        }
+
+        // TODO: match with the accountSalt added during initialization
+        // if (emailProof.accountSalt != emailData.accountSalt) {
+        //     return (false, "invalid account salt");
+        // }
+
+        if (
+            timestampCheckEnabled == true && jwtProof.timestamp < lastTimestamp
+        ) {
+            return (false, "invalid timestamp");
+        }
+
+        if (bytes(jwtProof.maskedCommand).length > verifier.getCommandBytes()) {
+            return (false, "invalid masked command length");
+        }
+
+        if (verifier.verifyEmailProof(jwtProof) == false) {
+            return (false, "invalid email proof");
+        }
+
+        // TODO: How to handle the nullifier update
+        // usedNullifiers[jwtProof.emailNullifier] = true;
+        // if (timestampCheckEnabled && jwtProof.timestamp != 0) {
+        //     lastTimestamp = jwtProof.timestamp;
+        // }
+
+        return (true, "");
+    }
+
+    /// @notice Enables or disables the timestamp check.
+    /// @dev This function can only be called by the controller.
+    /// @param _enabled Boolean flag to enable or disable the timestamp check.
+    function setTimestampCheckEnabled(bool _enabled) public {
+        timestampCheckEnabled = _enabled;
+    }
+}

--- a/src/JwtGuardianVerifier.sol
+++ b/src/JwtGuardianVerifier.sol
@@ -66,9 +66,8 @@ contract JwtGuardianVerifier is IGuardianVerifier, Initializable {
     // isCodeExit == false in the proof
     error CodeDoesNotExist();
 
-    // TODO: Update according to JWT Registry
-    // DKIM public key hash is not valid
-    error InvalidDKIMPublicKeyHash();
+    // public key hash is not valid
+    error InvalidPublicKeyHash();
 
     // Account salt is not the same as the salt used to derive the account address
     error InvalidAccountSalt(bytes32 accontSalt, bytes32 expectedAccountSalt);
@@ -171,7 +170,6 @@ contract JwtGuardianVerifier is IGuardianVerifier, Initializable {
      *
      * @return isVerified if the proof is valid
      */
-    // Lint Error: Cyclomatic complexity ( too many if else statements )
     function verifyProof(
         address account,
         ProofData memory proof
@@ -239,14 +237,13 @@ contract JwtGuardianVerifier is IGuardianVerifier, Initializable {
             proof: proof.proof
         });
 
-        // TODO: Handle JWT Registry check
-        // require(
-        //     jwtRegistry.isDKIMPublicKeyHashValid(
-        //         jwtProof.domainName,
-        //         jwtProof.publicKeyHash
-        //     ) == true,
-        //     "invalid dkim public key hash"
-        // );
+        require(
+            jwtRegistry.isDKIMPublicKeyHashValid(
+                jwtProof.domainName,
+                jwtProof.publicKeyHash
+            ) == true,
+            InvalidPublicKeyHash()
+        );
 
         require(
             accountSalt == jwtProof.accountSalt,

--- a/src/JwtGuardianVerifier.sol
+++ b/src/JwtGuardianVerifier.sol
@@ -137,17 +137,17 @@ contract JwtGuardianVerifier is IGuardianVerifier, Initializable {
         //     "invalid account salt"
         // );
 
-        require(
-            timestampCheckEnabled == false ||
-                jwtProof.timestamp == 0 ||
-                jwtProof.timestamp > lastTimestamp,
-            "invalid timestamp"
-        );
+        // require(
+        //     timestampCheckEnabled == false ||
+        //         jwtProof.timestamp == 0 ||
+        //         jwtProof.timestamp > lastTimestamp,
+        //     "invalid timestamp"
+        // );
 
-        require(
-            bytes(jwtProof.maskedCommand).length <= verifier.getCommandBytes(),
-            "invalid masked command length"
-        );
+        // require(
+        //     bytes(jwtProof.maskedCommand).length <= verifier.getCommandBytes(),
+        //     "invalid masked command length"
+        // );
 
         require(
             verifier.verifyEmailProof(jwtProof) == true,
@@ -226,15 +226,15 @@ contract JwtGuardianVerifier is IGuardianVerifier, Initializable {
         //     return (false, "invalid account salt");
         // }
 
-        if (
-            timestampCheckEnabled == true && jwtProof.timestamp < lastTimestamp
-        ) {
-            return (false, "invalid timestamp");
-        }
+        // if (
+        //     timestampCheckEnabled == true && jwtProof.timestamp < lastTimestamp
+        // ) {
+        //     return (false, "invalid timestamp");
+        // }
 
-        if (bytes(jwtProof.maskedCommand).length > verifier.getCommandBytes()) {
-            return (false, "invalid masked command length");
-        }
+        // if (bytes(jwtProof.maskedCommand).length > verifier.getCommandBytes()) {
+        //     return (false, "invalid masked command length");
+        // }
 
         if (verifier.verifyEmailProof(jwtProof) == false) {
             return (false, "invalid email proof");

--- a/src/interfaces/IGuardianVerifier.sol
+++ b/src/interfaces/IGuardianVerifier.sol
@@ -48,7 +48,7 @@ interface IGuardianVerifier {
 
     /**
      * @dev Verification logic of the proof
-     * To be used when nullifier based check for replay protection are required & not handeled at higher level
+     * Recommended to be used when nullifier based check for replay protection are required & not handeled at higher level
      * e.g. Email recovery functions ( handleAcceptance & handleRecovery )
      *
      * @notice Replay protection is handled by the verifier
@@ -62,7 +62,7 @@ interface IGuardianVerifier {
     function verifyProof(
         address account,
         ProofData memory proof
-    ) external view returns (bool isVerified);
+    ) external returns (bool isVerified);
 
     /**
      * @dev Verification logic of the proof

--- a/src/interfaces/IGuardianVerifier.sol
+++ b/src/interfaces/IGuardianVerifier.sol
@@ -48,8 +48,8 @@ interface IGuardianVerifier {
 
     /**
      * @dev Verification logic of the proof
-     * Recommended to be used when nullifier based check for replay protection are required & not handeled at higher level
-     * e.g. Email recovery functions ( handleAcceptance & handleRecovery )
+     * To be used when nullifier based check for replay protection are required & not handeled at higher level
+     * e.g. Recovery functions ( handleAcceptance & handleRecovery )
      *
      * @notice Replay protection is handled by the verifier
      * @notice Reverts if the proof is invalid

--- a/src/interfaces/IJwtVerifier.sol
+++ b/src/interfaces/IJwtVerifier.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+struct EmailProof {
+    string domainName; // Domain name of the sender's email
+    bytes32 publicKeyHash; // Hash of the DKIM public key used in email/proof
+    uint timestamp; // Timestamp of the email
+    string maskedCommand; // Masked command of the email
+    bytes32 emailNullifier; // Nullifier of the email to prevent its reuse.
+    bytes32 accountSalt; // Create2 salt of the account
+    bool isCodeExist; // Check if the account code is exist
+    bytes proof; // ZK Proof of Email
+}
+
+interface IVerifier {
+    /**
+     * @notice Verifies the provided email proof.
+     * @param proof The email proof to be verified.
+     * @return bool indicating whether the proof is valid.
+     */
+    function verifyEmailProof(
+        EmailProof memory proof
+    ) external view returns (bool);
+
+    /**
+     * @notice Returns a constant value representing command bytes.
+     * @return uint256 The constant value of command bytes.
+     */
+    function getCommandBytes() external pure returns (uint256);
+}

--- a/src/test/MockJwtVerifier.sol
+++ b/src/test/MockJwtVerifier.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.25;
+
+import {IVerifier, EmailProof} from "../interfaces/IJwtVerifier.sol";
+
+/**
+ * @notice Mock snarkjs Groth16 Solidity verifier
+ */
+contract MockJwtVerifier is IVerifier {
+    uint256 public constant DOMAIN_FIELDS = 9;
+    uint256 public constant DOMAIN_BYTES = 255;
+    uint256 public constant COMMAND_FIELDS = 20;
+    uint256 public constant COMMAND_BYTES = 605;
+
+    function getCommandBytes() external pure returns (uint256) {
+        return COMMAND_BYTES;
+    }
+
+    function verifyEmailProof(
+        EmailProof memory proof
+    ) public pure returns (bool) {
+        proof;
+
+        return true;
+    }
+}

--- a/test-new/Base.t.sol
+++ b/test-new/Base.t.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {RhinestoneModuleKit, AccountInstance} from "modulekit/ModuleKit.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+import {OwnableValidator} from "src/test/OwnableValidator.sol";
+
+/* solhint-disable gas-custom-errors, custom-errors, reason-string, max-states-count */
+
+abstract contract BaseTest is RhinestoneModuleKit, Test {
+    using Strings for uint256;
+
+    // ZK Email contracts and variables
+    address public zkEmailDeployer;
+
+    OwnableValidator public validator;
+    address public validatorAddress;
+
+    // public account and owners
+    address public owner1;
+    address public owner2;
+    address public owner3;
+    address public newOwner1;
+    address public newOwner2;
+    address public newOwner3;
+    AccountInstance public instance1;
+    AccountInstance public instance2;
+    AccountInstance public instance3;
+    address public accountAddress1;
+    address public accountAddress2;
+    address public accountAddress3;
+    address public killSwitchAuthorizer;
+
+    // public Account salts
+    bytes32 public accountSalt1;
+    bytes32 public accountSalt2;
+    bytes32 public accountSalt3;
+
+    // public recovery config
+    address[] public guardians1;
+    address[] public guardians2;
+    address[] public guardians3;
+    uint256[] public guardianWeights;
+    uint256 public totalWeight;
+    uint256 public delay;
+    uint256 public expiry;
+    uint256 public threshold;
+    bytes public isInstalledContext;
+
+    string public selector = "12345";
+    string public domainName = "gmail.com";
+    bytes32 public publicKeyHash =
+        0x0ea9c777dc7110e5a9e89b13f0cfc540e3845ba120b2b6dc24024d61488d4788;
+    uint256 public minimumDelay = 12 hours;
+
+    bytes4 public functionSelector;
+    bytes public recoveryCalldata;
+    bytes public recoveryData;
+    bytes32 public recoveryDataHash;
+
+    uint256 public nullifierCount;
+
+    function setUp() public virtual {
+        init();
+
+        // create owners
+        owner1 = vm.createWallet("owner1").addr;
+        owner2 = vm.createWallet("owner2").addr;
+        owner3 = vm.createWallet("owner3").addr;
+        newOwner1 = vm.createWallet("newOwner1").addr;
+        newOwner2 = vm.createWallet("newOwner2").addr;
+        newOwner3 = vm.createWallet("newOwner3").addr;
+
+        // Deploy and fund the accounts
+        instance1 = makeAccountInstance("account1");
+        instance2 = makeAccountInstance("account2");
+        instance3 = makeAccountInstance("account3");
+        accountAddress1 = instance1.account;
+        accountAddress2 = instance2.account;
+        accountAddress3 = instance3.account;
+        vm.deal(address(instance1.account), 10 ether);
+        vm.deal(address(instance2.account), 10 ether);
+        vm.deal(address(instance3.account), 10 ether);
+
+        accountSalt1 = keccak256(abi.encode("account salt 1"));
+        accountSalt2 = keccak256(abi.encode("account salt 2"));
+        accountSalt3 = keccak256(abi.encode("account salt 3"));
+
+        zkEmailDeployer = vm.addr(1);
+        killSwitchAuthorizer = vm.addr(2);
+
+        // Deploy validator to be recovered
+        validator = new OwnableValidator();
+        validatorAddress = address(validator);
+
+        setRecoveryData();
+
+        // Deploy the module
+        deployModule();
+
+        // Set recovery config variables
+        guardianWeights = new uint256[](3);
+        guardianWeights[0] = 1;
+        guardianWeights[1] = 2;
+        guardianWeights[2] = 1;
+        totalWeight = 4;
+        delay = 1 days;
+        expiry = 2 weeks;
+        threshold = 3;
+        isInstalledContext = bytes("0");
+    }
+
+    /**
+     * Return if current account type is safe or not
+     */
+    function isAccountTypeSafe() public view returns (bool) {
+        string memory currentAccountType = vm.envOr("ACCOUNT_TYPE", string(""));
+        if (Strings.equal(currentAccountType, "SAFE")) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Skip the test if the account type is not safe
+     */
+    function skipIfNotSafeAccountType() public {
+        if (isAccountTypeSafe()) {
+            vm.skip(false);
+        } else {
+            vm.skip(true);
+        }
+    }
+
+    function setRecoveryData() public virtual;
+
+    function deployModule() public virtual;
+
+    function computeGuardianVerifierAuthAddress(
+        address guardianVerifierImplementation,
+        address account,
+        bytes32 accountSalt,
+        bytes memory verifierInitData
+    ) public view virtual returns (address);
+
+    function getAccountSaltForGuardian(
+        address account,
+        address guardian
+    ) public view returns (bytes32) {
+        address[] memory guardians;
+        if (account == instance1.account) {
+            guardians = guardians1;
+        } else if (account == instance2.account) {
+            guardians = guardians2;
+        } else if (account == instance3.account) {
+            guardians = guardians3;
+        } else {
+            revert("getAccountSaltForGuardian - Invalid account address");
+        }
+        if (guardian == guardians[0]) {
+            return accountSalt1;
+        }
+        if (guardian == guardians[1]) {
+            return accountSalt2;
+        }
+        if (guardian == guardians[2]) {
+            return accountSalt3;
+        }
+
+        revert("getAccountSaltForGuardian - Invalid guardian address");
+    }
+
+    function generateNewNullifier() public returns (bytes32) {
+        return keccak256(abi.encode(nullifierCount++));
+    }
+}

--- a/test-new/JwtGuardianVerifier/JwtGuardianVerifier.t.sol
+++ b/test-new/JwtGuardianVerifier/JwtGuardianVerifier.t.sol
@@ -10,6 +10,7 @@ import {IGuardianManager} from "src/interfaces/IGuardianManager.sol";
 import {GuardianStorage, GuardianStatus} from "src/libraries/EnumerableGuardianMap.sol";
 
 import {OwnableValidatorRecovery_AbstractedRecoveryModule_Base} from "./JwtGuardianVerifierBase.t.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 /**
  * Test the abstracted recovery module with jwt based guardians
@@ -32,20 +33,20 @@ contract OwnableValidatorRecovery_AbstractedRecoveryModule_Test is
         bytes memory recoveryData
     ) internal {
         acceptGuardian(
-            emailGuardianVerifierImplementation,
+            jwtGuardianVerifierImplementation,
             account,
             guardians[0],
             emailRecoveryModuleAddress,
             accountSalt1,
-            emailGuardianVerifierInitData
+            jwtGuardianVerifierInitData
         );
         acceptGuardian(
-            emailGuardianVerifierImplementation,
+            jwtGuardianVerifierImplementation,
             account,
             guardians[1],
             emailRecoveryModuleAddress,
             accountSalt2,
-            emailGuardianVerifierInitData
+            jwtGuardianVerifierInitData
         );
         vm.warp(block.timestamp + 12 seconds);
         handleRecovery(
@@ -68,8 +69,6 @@ contract OwnableValidatorRecovery_AbstractedRecoveryModule_Test is
 
     // End to end test
     function test_Recover_RotatesOwnerSuccessfully() public {
-        skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
-
         // Accept guardian 1
         acceptGuardian(
             jwtGuardianVerifierImplementation,

--- a/test-new/JwtGuardianVerifier/JwtGuardianVerifier.t.sol
+++ b/test-new/JwtGuardianVerifier/JwtGuardianVerifier.t.sol
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ModuleKitHelpers, AccountInstance} from "modulekit/ModuleKit.sol";
+import {MODULE_TYPE_EXECUTOR} from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
+import {EmailAccountRecovery} from "@zk-email/ether-email-auth-contracts/src/EmailAccountRecovery.sol";
+
+import {IEmailRecoveryManager} from "src/interfaces/IEmailRecoveryManager.sol";
+import {IGuardianManager} from "src/interfaces/IGuardianManager.sol";
+import {GuardianStorage, GuardianStatus} from "src/libraries/EnumerableGuardianMap.sol";
+
+import {OwnableValidatorRecovery_AbstractedRecoveryModule_Base} from "./JwtGuardianVerifierBase.t.sol";
+
+/**
+ * Test the abstracted recovery module with jwt based guardians
+ */
+contract OwnableValidatorRecovery_AbstractedRecoveryModule_Test is
+    OwnableValidatorRecovery_AbstractedRecoveryModule_Base
+{
+    using ModuleKitHelpers for *;
+    using Strings for uint256;
+
+    function setUp() public override {
+        super.setUp();
+    }
+
+    // Helper function
+    function executeRecoveryFlowForAccount(
+        address account,
+        address[] memory guardians,
+        bytes32 recoveryDataHash,
+        bytes memory recoveryData
+    ) internal {
+        acceptGuardian(
+            emailGuardianVerifierImplementation,
+            account,
+            guardians[0],
+            emailRecoveryModuleAddress,
+            accountSalt1,
+            emailGuardianVerifierInitData
+        );
+        acceptGuardian(
+            emailGuardianVerifierImplementation,
+            account,
+            guardians[1],
+            emailRecoveryModuleAddress,
+            accountSalt2,
+            emailGuardianVerifierInitData
+        );
+        vm.warp(block.timestamp + 12 seconds);
+        handleRecovery(
+            account,
+            guardians[0],
+            recoveryDataHash,
+            emailRecoveryModuleAddress,
+            accountSalt1
+        );
+        handleRecovery(
+            account,
+            guardians[1],
+            recoveryDataHash,
+            emailRecoveryModuleAddress,
+            accountSalt1
+        );
+        vm.warp(block.timestamp + delay);
+        emailRecoveryModule.completeRecovery(account, recoveryData);
+    }
+
+    // End to end test
+    function test_Recover_RotatesOwnerSuccessfully() public {
+        skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
+
+        // Accept guardian 1
+        acceptGuardian(
+            jwtGuardianVerifierImplementation,
+            accountAddress1,
+            guardians1[0],
+            emailRecoveryModuleAddress,
+            accountSalt1,
+            jwtGuardianVerifierInitData
+        );
+        GuardianStorage memory guardianStorage1 = emailRecoveryModule
+            .getGuardian(accountAddress1, guardians1[0]);
+        assertEq(
+            uint256(guardianStorage1.status),
+            uint256(GuardianStatus.ACCEPTED)
+        );
+        assertEq(guardianStorage1.weight, uint256(1));
+
+        // Accept guardian 2
+        acceptGuardian(
+            jwtGuardianVerifierImplementation,
+            accountAddress1,
+            guardians1[1],
+            emailRecoveryModuleAddress,
+            accountSalt2,
+            jwtGuardianVerifierInitData
+        );
+
+        GuardianStorage memory guardianStorage2 = emailRecoveryModule
+            .getGuardian(accountAddress1, guardians1[1]);
+        assertEq(
+            uint256(guardianStorage2.status),
+            uint256(GuardianStatus.ACCEPTED)
+        );
+        assertEq(guardianStorage2.weight, uint256(2));
+
+        // Time travel so that EmailAuth timestamp is valid
+        vm.warp(12 seconds);
+
+        // handle recovery request for guardian 1
+        handleRecovery(
+            accountAddress1,
+            guardians1[0],
+            recoveryDataHash1,
+            emailRecoveryModuleAddress,
+            accountSalt1
+        );
+        uint256 executeBefore = block.timestamp + expiry;
+        (
+            uint256 _executeAfter,
+            uint256 _executeBefore,
+            uint256 currentWeight,
+            bytes32 recoveryDataHash
+        ) = emailRecoveryModule.getRecoveryRequest(accountAddress1);
+        bool hasGuardian1Voted = emailRecoveryModule.hasGuardianVoted(
+            accountAddress1,
+            guardians1[0]
+        );
+        bool hasGuardian2Voted = emailRecoveryModule.hasGuardianVoted(
+            accountAddress1,
+            guardians1[1]
+        );
+        assertEq(_executeAfter, 0);
+        assertEq(_executeBefore, executeBefore);
+        assertEq(currentWeight, 1);
+        assertEq(recoveryDataHash, recoveryDataHash1);
+        assertEq(hasGuardian1Voted, true);
+        assertEq(hasGuardian2Voted, false);
+
+        // handle recovery request for guardian 2
+        uint256 executeAfter = block.timestamp + delay;
+        handleRecovery(
+            accountAddress1,
+            guardians1[1],
+            recoveryDataHash1,
+            emailRecoveryModuleAddress,
+            accountSalt2
+        );
+        (
+            _executeAfter,
+            _executeBefore,
+            currentWeight,
+            recoveryDataHash
+        ) = emailRecoveryModule.getRecoveryRequest(accountAddress1);
+        hasGuardian1Voted = emailRecoveryModule.hasGuardianVoted(
+            accountAddress1,
+            guardians1[0]
+        );
+        hasGuardian2Voted = emailRecoveryModule.hasGuardianVoted(
+            accountAddress1,
+            guardians1[1]
+        );
+        assertEq(_executeAfter, executeAfter);
+        assertEq(_executeBefore, executeBefore);
+        assertEq(currentWeight, 3);
+        assertEq(recoveryDataHash, recoveryDataHash1);
+        assertEq(hasGuardian1Voted, true);
+        assertEq(hasGuardian2Voted, true);
+
+        // Time travel so that the recovery delay has passed
+        vm.warp(block.timestamp + delay);
+
+        // Complete recovery
+        emailRecoveryModule.completeRecovery(accountAddress1, recoveryData1);
+
+        (
+            _executeAfter,
+            _executeBefore,
+            currentWeight,
+            recoveryDataHash
+        ) = emailRecoveryModule.getRecoveryRequest(accountAddress1);
+        hasGuardian1Voted = emailRecoveryModule.hasGuardianVoted(
+            accountAddress1,
+            guardians1[0]
+        );
+        hasGuardian2Voted = emailRecoveryModule.hasGuardianVoted(
+            accountAddress1,
+            guardians1[1]
+        );
+        address updatedOwner = validator.owners(accountAddress1);
+
+        assertEq(_executeAfter, 0);
+        assertEq(_executeBefore, 0);
+        assertEq(currentWeight, 0);
+        assertEq(recoveryDataHash, bytes32(0));
+        assertEq(hasGuardian1Voted, false);
+        assertEq(hasGuardian2Voted, false);
+        assertEq(updatedOwner, newOwner1);
+    }
+
+    // function test_Recover_RevertWhen_MixAccountHandleAcceptance() public {
+    //     skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
+
+    //     acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
+    //     acceptGuardianWithAccountSalt(
+    //         accountAddress2, guardians1[1], emailRecoveryModuleAddress, accountSalt2
+    //     );
+    //     vm.warp(12 seconds);
+
+    //     EmailAuthMsg memory emailAuthMsg = getRecoveryEmailAuthMessage(
+    //         accountAddress1, guardians1[1], recoveryDataHash1, emailRecoveryModuleAddress
+    //     );
+
+    //     vm.expectRevert("guardian is not deployed");
+    //     emailRecoveryModule.handleRecovery(emailAuthMsg, templateIdx);
+
+    //     emailAuthMsg = getRecoveryEmailAuthMessage(
+    //         accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
+    //     );
+
+    //     vm.expectRevert(
+    //         abi.encodeWithSelector(
+    //             IEmailRecoveryManager.ThresholdExceedsAcceptedWeight.selector, 3, 1
+    //         )
+    //     );
+    //     emailRecoveryModule.handleRecovery(emailAuthMsg, templateIdx);
+    // }
+
+    // function test_Recover_RevertWhen_MixAccountHandleRecovery() public {
+    //     skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
+
+    //     acceptGuardianWithAccountSalt(
+    //         accountAddress2, guardians1[1], emailRecoveryModuleAddress, accountSalt2
+    //     );
+
+    //     acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
+    //     acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
+    //     vm.warp(block.timestamp + 12 seconds);
+    //     handleRecovery(
+    //         accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
+    //     );
+
+    //     EmailAuthMsg memory emailAuthMsg = getRecoveryEmailAuthMessageWithAccountSalt(
+    //         accountAddress2,
+    //         guardians1[1],
+    //         recoveryDataHash2,
+    //         emailRecoveryModuleAddress,
+    //         accountSalt2
+    //     );
+
+    //     vm.expectRevert(
+    //         abi.encodeWithSelector(
+    //             IEmailRecoveryManager.ThresholdExceedsAcceptedWeight.selector,
+    //             uint256(3),
+    //             uint256(2)
+    //         )
+    //     );
+    //     emailRecoveryModule.handleRecovery(emailAuthMsg, templateIdx);
+    // }
+
+    // function test_Recover_RevertWhen_UninstallModuleBeforeAnyGuardiansAccepted() public {
+    //     skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
+
+    //     instance1.uninstallModule(MODULE_TYPE_EXECUTOR, emailRecoveryModuleAddress, "");
+
+    //     EmailAuthMsg memory emailAuthMsg = getAcceptanceEmailAuthMessage(
+    //         accountAddress1, guardians1[0], emailRecoveryModuleAddress
+    //     );
+
+    //     vm.expectRevert(IEmailRecoveryManager.RecoveryIsNotActivated.selector);
+    //     emailRecoveryModule.handleAcceptance(emailAuthMsg, templateIdx);
+    // }
+
+    // function test_Recover_RevertWhen_UninstallModuleBeforeEnoughAcceptedAndTryHandleAcceptance()
+    //     public
+    // {
+    //     skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
+
+    //     acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
+    //     instance1.uninstallModule(MODULE_TYPE_EXECUTOR, emailRecoveryModuleAddress, "");
+
+    //     EmailAuthMsg memory emailAuthMsg = getAcceptanceEmailAuthMessage(
+    //         accountAddress1, guardians1[1], emailRecoveryModuleAddress
+    //     );
+
+    //     vm.expectRevert(IEmailRecoveryManager.RecoveryIsNotActivated.selector);
+    //     emailRecoveryModule.handleAcceptance(emailAuthMsg, templateIdx);
+    // }
+
+    // function test_Recover_RevertWhen_UninstallModuleAfterEnoughAcceptedAndTryHandleRecovery()
+    //     public
+    // {
+    //     skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
+
+    //     acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
+    //     acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
+    //     vm.warp(12 seconds);
+
+    //     EmailAuthMsg memory emailAuthMsg = getRecoveryEmailAuthMessage(
+    //         accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
+    //     );
+
+    //     instance1.uninstallModule(MODULE_TYPE_EXECUTOR, emailRecoveryModuleAddress, "");
+
+    //     vm.expectRevert(IEmailRecoveryManager.RecoveryIsNotActivated.selector);
+    //     emailRecoveryModule.handleRecovery(emailAuthMsg, templateIdx);
+    // }
+
+    // function test_Recover_RevertWhen_UninstallModuleAfterOneApprovalAndTryHandleRecovery() public {
+    //     skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
+
+    //     acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
+    //     acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
+    //     vm.warp(12 seconds);
+    //     handleRecovery(
+    //         accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
+    //     );
+
+    //     vm.startPrank(accountAddress1);
+    //     vm.expectRevert(IGuardianManager.RecoveryInProcess.selector);
+    //     emailRecoveryModule.onUninstall("");
+    // }
+
+    // function test_Recover_RevertWhen_UninstallModuleProcessRecoveryAndTryCompleteRecovery()
+    //     public
+    // {
+    //     skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
+
+    //     acceptGuardian(accountAddress1, guardians1[0], emailRecoveryModuleAddress);
+    //     acceptGuardian(accountAddress1, guardians1[1], emailRecoveryModuleAddress);
+    //     vm.warp(12 seconds);
+    //     handleRecovery(
+    //         accountAddress1, guardians1[0], recoveryDataHash1, emailRecoveryModuleAddress
+    //     );
+    //     handleRecovery(
+    //         accountAddress1, guardians1[1], recoveryDataHash1, emailRecoveryModuleAddress
+    //     );
+    //     vm.warp(block.timestamp + delay);
+
+    //     vm.startPrank(accountAddress1);
+    //     vm.expectRevert(IGuardianManager.RecoveryInProcess.selector);
+    //     emailRecoveryModule.onUninstall("");
+    // }
+
+    // function test_Recover_RevertWhen_UninstallModuleAndTryRecoveryAgain() public {
+    //     skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
+
+    //     executeRecoveryFlowForAccount(accountAddress1, guardians1, recoveryDataHash1, recoveryData1);
+    //     address updatedOwner1 = validator.owners(accountAddress1);
+    //     assertEq(updatedOwner1, newOwner1);
+
+    //     instance1.uninstallModule(MODULE_TYPE_EXECUTOR, emailRecoveryModuleAddress, "");
+
+    //     EmailAuthMsg memory emailAuthMsg = getAcceptanceEmailAuthMessage(
+    //         accountAddress1, guardians1[0], emailRecoveryModuleAddress
+    //     );
+
+    //     vm.expectRevert(IEmailRecoveryManager.RecoveryIsNotActivated.selector);
+    //     emailRecoveryModule.handleAcceptance(emailAuthMsg, templateIdx);
+    // }
+
+    // function test_Recover_UninstallModuleAndRecoverAgain() public {
+    //     skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
+
+    //     executeRecoveryFlowForAccount(accountAddress1, guardians1, recoveryDataHash1, recoveryData1);
+    //     address updatedOwner = validator.owners(accountAddress1);
+    //     assertEq(updatedOwner, newOwner1);
+
+    //     instance1.uninstallModule(MODULE_TYPE_EXECUTOR, emailRecoveryModuleAddress, "");
+    //     instance1.installModule({
+    //         moduleTypeId: MODULE_TYPE_EXECUTOR,
+    //         module: emailRecoveryModuleAddress,
+    //         data: abi.encode(isInstalledContext, guardians1, guardianWeights, threshold, delay, expiry)
+    //     });
+
+    //     bytes memory newChangeOwnerCalldata = abi.encodeWithSelector(functionSelector, newOwner2);
+    //     bytes memory newRecoveryData = abi.encode(validatorAddress, newChangeOwnerCalldata);
+    //     bytes32 newRecoveryDataHash = keccak256(newRecoveryData);
+    //     executeRecoveryFlowForAccount(
+    //         accountAddress1, guardians1, newRecoveryDataHash, newRecoveryData
+    //     );
+
+    //     updatedOwner = validator.owners(accountAddress1);
+    //     assertEq(updatedOwner, newOwner2);
+    // }
+
+    // function test_Recover_RotatesMultipleOwnersSuccessfully() public {
+    //     skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
+
+    //     executeRecoveryFlowForAccount(accountAddress1, guardians1, recoveryDataHash1, recoveryData1);
+    //     executeRecoveryFlowForAccount(accountAddress2, guardians2, recoveryDataHash2, recoveryData2);
+    //     executeRecoveryFlowForAccount(accountAddress3, guardians3, recoveryDataHash3, recoveryData3);
+
+    //     address updatedOwner1 = validator.owners(accountAddress1);
+    //     address updatedOwner2 = validator.owners(accountAddress2);
+    //     address updatedOwner3 = validator.owners(accountAddress3);
+    //     assertEq(updatedOwner1, newOwner1);
+    //     assertEq(updatedOwner2, newOwner2);
+    //     assertEq(updatedOwner3, newOwner3);
+    // }
+
+    // function test_ActivateKillSwitchDoesNotImpactOtherModules() public {
+    //     skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
+
+    //     bytes32 commandHandlerSalt = bytes32(uint256(1));
+    //     bytes32 recoveryModuleSalt = bytes32(uint256(1));
+    //     (address newRecoveryModuleAddress,) = emailRecoveryFactory.deployEmailRecoveryModule(
+    //         commandHandlerSalt,
+    //         recoveryModuleSalt,
+    //         getHandlerBytecode(),
+    //         minimumDelay,
+    //         killSwitchAuthorizer,
+    //         address(dkimRegistry),
+    //         validatorAddress,
+    //         functionSelector
+    //     );
+    //     AccountInstance memory newAccountInstance = makeAccountInstance("account1");
+    //     newAccountInstance.installModule({
+    //         moduleTypeId: MODULE_TYPE_EXECUTOR,
+    //         module: newRecoveryModuleAddress,
+    //         data: abi.encode(isInstalledContext, guardians1, guardianWeights, threshold, delay, expiry)
+    //     });
+
+    //     vm.prank(killSwitchAuthorizer);
+    //     IEmailRecoveryManager(newRecoveryModuleAddress).toggleKillSwitch();
+    //     vm.stopPrank();
+
+    //     // toggling kill switch for one module does not inpact other modules
+    //     executeRecoveryFlowForAccount(accountAddress1, guardians1, recoveryDataHash1, recoveryData1);
+
+    //     // new module should not be useable
+    //     vm.expectRevert(IGuardianManager.KillSwitchEnabled.selector);
+    //     EmailAccountRecovery(newRecoveryModuleAddress).completeRecovery(
+    //         accountAddress1, abi.encodePacked("1")
+    //     );
+    //     executeRecoveryFlowForAccount(accountAddress2, guardians2, recoveryDataHash2, recoveryData2);
+    //     executeRecoveryFlowForAccount(accountAddress3, guardians3, recoveryDataHash3, recoveryData3);
+
+    //     address updatedOwner1 = validator.owners(accountAddress1);
+    //     address updatedOwner2 = validator.owners(accountAddress2);
+    //     address updatedOwner3 = validator.owners(accountAddress3);
+    //     assertEq(updatedOwner1, newOwner1);
+    //     assertEq(updatedOwner2, newOwner2);
+    //     assertEq(updatedOwner3, newOwner3);
+    // }
+
+    // function test_Recover_RevertWhenUninstallModuleAndRecoverAgainWithKillSwitch() public {
+    //     skipIfCommandHandlerType(CommandHandlerType.SafeRecoveryCommandHandler);
+    //     string memory currentAccountType = vm.envOr("ACCOUNT_TYPE", string(""));
+    //     if (bytes(currentAccountType).length == 0 || Strings.equal(currentAccountType, "DEFAULT")) {
+    //         vm.skip(false);
+    //     } else {
+    //         vm.skip(true);
+    //     }
+
+    //     executeRecoveryFlowForAccount(accountAddress1, guardians1, recoveryDataHash1, recoveryData1);
+    //     address updatedOwner = validator.owners(accountAddress1);
+    //     assertEq(updatedOwner, newOwner1);
+
+    //     vm.prank(killSwitchAuthorizer);
+    //     IEmailRecoveryManager(emailRecoveryModuleAddress).toggleKillSwitch();
+    //     vm.stopPrank();
+
+    //     instance1.uninstallModule(MODULE_TYPE_EXECUTOR, emailRecoveryModuleAddress, "");
+    //     // the second module installation should fail after the kill switch is enabled.
+    //     instance1.expect4337Revert(IGuardianManager.KillSwitchEnabled.selector);
+    //     instance1.installModule({
+    //         moduleTypeId: MODULE_TYPE_EXECUTOR,
+    //         module: emailRecoveryModuleAddress,
+    //         data: abi.encode(isInstalledContext, guardians1, guardianWeights, threshold, delay, expiry)
+    //     });
+    // }
+}

--- a/test-new/JwtGuardianVerifier/JwtGuardianVerifierBase.t.sol
+++ b/test-new/JwtGuardianVerifier/JwtGuardianVerifierBase.t.sol
@@ -75,7 +75,6 @@ abstract contract OwnableValidatorRecovery_AbstractedRecoveryModule_Base is
 
         vm.startPrank(zkEmailDeployer);
 
-        // TODO: JWT Registry is not yet implemented in test
         uint256 setTimeDelay = 0;
         UserOverrideableDKIMRegistry overrideableDkimImpl = new UserOverrideableDKIMRegistry();
         ERC1967Proxy dkimProxy = new ERC1967Proxy(
@@ -87,8 +86,11 @@ abstract contract OwnableValidatorRecovery_AbstractedRecoveryModule_Base is
         );
         dkimRegistry = UserOverrideableDKIMRegistry(address(dkimProxy));
 
+        string
+            memory jwtDomainName = "12345|https://example.com|client-id-12345";
+
         dkimRegistry.setDKIMPublicKeyHash(
-            domainName,
+            jwtDomainName,
             publicKeyHash,
             zkEmailDeployer,
             new bytes(0)
@@ -210,22 +212,16 @@ abstract contract OwnableValidatorRecovery_AbstractedRecoveryModule_Base is
         recoveryDataHash = keccak256(recoveryData);
     }
 
-    // TODO: Implement the following function
     function generateMockJwtProof(
         string memory command,
         bytes32 nullifier,
         bytes32 accountSalt
     ) public view returns (EmailProof memory) {
         EmailProof memory emailProof;
-        emailProof
-            .domainName = "ee193d4647ab4a3585aa9b2b3b484a87aa68bb42|https://accounts.google.com|397234807794-fh6mhl0jppgtt0ak5cgikhlesbe8f7si.apps.googleusercontent.com";
+        emailProof.domainName = "12345|https://example.com|client-id-12345";
 
-        // TODO: Public key hash is not derived from decoded jwt
-        emailProof.publicKeyHash = bytes32(
-            vm.parseUint(
-                "6632353713085157925504008443078919716322386156160602218536961028046468237192"
-            )
-        );
+        emailProof
+            .publicKeyHash = 0x0ea9c777dc7110e5a9e89b13f0cfc540e3845ba120b2b6dc24024d61488d4788;
         emailProof.timestamp = block.timestamp;
         emailProof.maskedCommand = command;
         emailProof.emailNullifier = nullifier;

--- a/test-new/JwtGuardianVerifier/JwtGuardianVerifierBase.t.sol
+++ b/test-new/JwtGuardianVerifier/JwtGuardianVerifierBase.t.sol
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ModuleKitHelpers} from "modulekit/ModuleKit.sol";
+import {MODULE_TYPE_EXECUTOR, MODULE_TYPE_VALIDATOR} from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
+
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {EmailRecoveryFactory} from "src/factories/EmailRecoveryFactory.sol";
+import {EmailRecoveryModule} from "src/modules/EmailRecoveryModule.sol";
+
+import {BaseTest, CommandHandlerType} from "../Base.t.sol";
+
+import {EmailProof} from "@zk-email/ether-email-auth-contracts/src/interfaces/IVerifier.sol";
+
+import {MockJwtVerifier} from "src/test/MockJwtVerifier.sol";
+import {JwtGuardianVerifier} from "src/JwtGuardianVerifier.sol";
+import {IGuardianVerifier} from "src/interfaces/IGuardianVerifier.sol";
+
+import {UserOverrideableDKIMRegistry} from "@zk-email/contracts/UserOverrideableDKIMRegistry.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+interface IEmailRecoveryModule {
+    function handleAcceptance(
+        address guardianVerifierImplementation,
+        address account,
+        bytes32 accountSalt,
+        bytes memory verifierInitData,
+        IGuardianVerifier.ProofData memory proofData
+    ) external;
+
+    function handleRecovery(
+        address guardian,
+        address account,
+        bytes32 accountSalt,
+        bytes32 recoveryDataHash,
+        IGuardianVerifier.ProofData memory proofData
+    ) external;
+
+    function completeRecovery(
+        address account,
+        bytes memory completeCalldata
+    ) external;
+}
+
+/**
+ * Base setup for Jwt Guardian verifier
+ */
+abstract contract OwnableValidatorRecovery_AbstractedRecoveryModule_Base is
+    BaseTest
+{
+    UserOverrideableDKIMRegistry public dkimRegistry;
+    MockGroth16Verifier public verifier;
+
+    using ModuleKitHelpers for *;
+    using Strings for uint256;
+    using Strings for address;
+
+    EmailRecoveryFactory public emailRecoveryFactory;
+    EmailRecoveryModule public emailRecoveryModule;
+
+    address public emailRecoveryModuleAddress;
+
+    bytes public recoveryData1;
+    bytes public recoveryData2;
+    bytes public recoveryData3;
+    bytes32 public recoveryDataHash1;
+    bytes32 public recoveryDataHash2;
+    bytes32 public recoveryDataHash3;
+
+    address public jwtGuardianVerifierImplementation;
+    bytes public jwtGuardianVerifierInitData;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        vm.startPrank(zkEmailDeployer);
+
+        uint256 setTimeDelay = 0;
+        UserOverrideableDKIMRegistry overrideableDkimImpl = new UserOverrideableDKIMRegistry();
+        ERC1967Proxy dkimProxy = new ERC1967Proxy(
+            address(overrideableDkimImpl),
+            abi.encodeCall(
+                overrideableDkimImpl.initialize,
+                (zkEmailDeployer, zkEmailDeployer, setTimeDelay)
+            )
+        );
+        dkimRegistry = UserOverrideableDKIMRegistry(address(dkimProxy));
+
+        dkimRegistry.setDKIMPublicKeyHash(
+            domainName,
+            publicKeyHash,
+            zkEmailDeployer,
+            new bytes(0)
+        );
+
+        verifier = new MockJwtVerifier();
+
+        vm.stopPrank();
+
+        // Setup for the email guardian verifier
+        bytes memory initData = abi.encode(
+            address(dkimRegistry),
+            address(verifier)
+        );
+        jwtGuardianVerifierInitData = initData;
+
+        // Deploy the email guardian verifier
+        jwtGuardianVerifierImplementation = address(new JwtGuardianVerifier());
+
+        guardians1 = new address[](3);
+        guardians1[0] = computeGuardianVerifierAuthAddress(
+            jwtGuardianVerifierImplementation,
+            instance1.account,
+            accountSalt1,
+            jwtGuardianVerifierInitData
+        );
+        guardians1[1] = computeGuardianVerifierAuthAddress(
+            jwtGuardianVerifierImplementation,
+            instance1.account,
+            accountSalt2,
+            jwtGuardianVerifierInitData
+        );
+        guardians1[2] = computeGuardianVerifierAuthAddress(
+            jwtGuardianVerifierImplementation,
+            instance1.account,
+            accountSalt3,
+            jwtGuardianVerifierInitData
+        );
+
+        // INITIAL SETUP
+        bytes memory changeOwnerCalldata1 = abi.encodeWithSelector(
+            functionSelector,
+            newOwner1
+        );
+        bytes memory changeOwnerCalldata2 = abi.encodeWithSelector(
+            functionSelector,
+            newOwner2
+        );
+        bytes memory changeOwnerCalldata3 = abi.encodeWithSelector(
+            functionSelector,
+            newOwner3
+        );
+        recoveryData1 = abi.encode(validatorAddress, changeOwnerCalldata1);
+        recoveryData2 = abi.encode(validatorAddress, changeOwnerCalldata2);
+        recoveryData3 = abi.encode(validatorAddress, changeOwnerCalldata3);
+        recoveryDataHash1 = keccak256(recoveryData1);
+        recoveryDataHash2 = keccak256(recoveryData2);
+        recoveryDataHash3 = keccak256(recoveryData3);
+
+        bytes memory recoveryModuleInstallData1 = abi.encode(
+            isInstalledContext,
+            guardians1,
+            guardianWeights,
+            threshold,
+            delay,
+            expiry
+        );
+
+        // Install modules for account 1
+        instance1.installModule({
+            moduleTypeId: MODULE_TYPE_VALIDATOR,
+            module: validatorAddress,
+            data: abi.encode(owner1)
+        });
+        instance1.installModule({
+            moduleTypeId: MODULE_TYPE_EXECUTOR,
+            module: emailRecoveryModuleAddress,
+            data: recoveryModuleInstallData1
+        });
+    }
+
+    // Helper functions
+    function computeGuardianVerifierAuthAddress(
+        address guardianVerifierImplementation,
+        address account,
+        bytes32 accountSalt,
+        bytes memory verifierInitData
+    ) public view override returns (address) {
+        return
+            emailRecoveryModule.computeGuardianVerifierAddress(
+                guardianVerifierImplementation,
+                account,
+                accountSalt,
+                verifierInitData
+            );
+    }
+
+    // Helper functions
+    function deployModule() public override {
+        // Deploy the email recovery factory after removing email guardian verifier related logic
+        emailRecoveryFactory = new EmailRecoveryFactory();
+
+        bytes32 recoveryModuleSalt = bytes32(uint256(0));
+        emailRecoveryModuleAddress = emailRecoveryFactory
+            .deployEmailRecoveryModule(
+                recoveryModuleSalt,
+                minimumDelay,
+                killSwitchAuthorizer,
+                validatorAddress,
+                functionSelector
+            );
+        emailRecoveryModule = EmailRecoveryModule(emailRecoveryModuleAddress);
+
+        if (
+            getCommandHandlerType() ==
+            CommandHandlerType.AccountHidingRecoveryCommandHandler
+        ) {
+            AccountHidingRecoveryCommandHandler(commandHandlerAddress)
+                .storeAccountHash(accountAddress1);
+            AccountHidingRecoveryCommandHandler(commandHandlerAddress)
+                .storeAccountHash(accountAddress2);
+            AccountHidingRecoveryCommandHandler(commandHandlerAddress)
+                .storeAccountHash(accountAddress3);
+        }
+    }
+
+    // Helper functions
+    function setRecoveryData() public override {
+        functionSelector = bytes4(keccak256(bytes("changeOwner(address)")));
+        recoveryCalldata = abi.encodeWithSelector(functionSelector, newOwner1);
+        recoveryData = abi.encode(validatorAddress, recoveryCalldata);
+        recoveryDataHash = keccak256(recoveryData);
+    }
+
+    // TODO: Implement the following function
+    function generateMockJwtProof(
+        string memory command,
+        bytes32 nullifier,
+        bytes32 accountSalt
+    ) public view returns (EmailProof memory) {
+        EmailProof memory emailProof;
+        emailProof.domainName = "gmail.com";
+        emailProof.publicKeyHash = bytes32(
+            vm.parseUint(
+                "6632353713085157925504008443078919716322386156160602218536961028046468237192"
+            )
+        );
+        emailProof.timestamp = block.timestamp;
+        emailProof.maskedCommand = command;
+        emailProof.emailNullifier = nullifier;
+        emailProof.accountSalt = accountSalt;
+        emailProof.isCodeExist = true;
+        emailProof.proof = bytes("0");
+
+        return emailProof;
+    }
+
+    function acceptGuardian(
+        address guardianVerifierImplementation,
+        address account,
+        address guardian,
+        address emailRecoveryModule,
+        bytes32 accountSalt,
+        bytes memory verifierInitData
+    ) public {
+        EmailGuardianVerifier.ProofData
+            memory proofData = getAcceptanceJwtProofData(
+                account,
+                guardian,
+                emailRecoveryModule,
+                accountSalt
+            );
+        IEmailRecoveryModule(emailRecoveryModule).handleAcceptance(
+            guardianVerifierImplementation,
+            account,
+            accountSalt,
+            verifierInitData,
+            proofData
+        );
+    }
+
+    function getAcceptanceJwtProofData(
+        address account,
+        address guardian,
+        address emailRecoveryModule,
+        bytes32 accountSalt
+    ) public returns (IGuardianVerifier.ProofData memory proofData) {
+        bytes32 nullifier = generateNewNullifier();
+
+        EmailProof memory jwtProof = generateMockJwtProof(
+            command,
+            nullifier,
+            accountSalt
+        );
+
+        JwtGuardianVerifier.JwtData memory jwtData = EmailGuardianVerifier
+            .JwtData({
+                domainName: jwtProof.domainName,
+                timestamp: jwtProof.timestamp,
+                maskedCommand: jwtProof.maskedCommand,
+                accountSalt: accountSalt,
+                isCodeExist: jwtProof.isCodeExist,
+                isRecovery: false // Acceptance
+            });
+
+        bytes32[] memory acceptancePublicInputs = new bytes32[](2);
+        acceptancePublicInputs[0] = jwtProof.publicKeyHash; // publicKeyHash
+        acceptancePublicInputs[1] = jwtProof.emailNullifier; // emailNullifier
+
+        proofData = IGuardianVerifier.ProofData({
+            proof: emailProof.proof,
+            publicInputs: acceptancePublicInputs,
+            data: abi.encode(jwtData)
+        });
+    }
+
+    function handleRecovery(
+        address account,
+        address guardian,
+        bytes32 _recoveryDataHash,
+        address emailRecoveryModule,
+        bytes32 accountSalt
+    ) public {
+        EmailGuardianVerifier.ProofData
+            memory proofData = getRecoveryJwtProofData(
+                account,
+                guardian,
+                _recoveryDataHash,
+                emailRecoveryModule,
+                accountSalt
+            );
+        IEmailRecoveryModule(emailRecoveryModule).handleRecovery(
+            guardian,
+            account,
+            accountSalt,
+            _recoveryDataHash,
+            proofData
+        );
+    }
+
+    // WithAccountSalt variation - used for creating incorrect recovery setups
+    function getRecoveryJwtProofData(
+        address account,
+        address guardian,
+        bytes32 _recoveryDataHash,
+        address emailRecoveryModule,
+        bytes32 accountSalt
+    ) public returns (IGuardianVerifier.ProofData memory proofData) {
+        bytes32 nullifier = generateNewNullifier();
+
+        EmailProof memory jwtProof = generateMockJwtProof(
+            command,
+            nullifier,
+            accountSalt
+        );
+
+        JwtGuardianVerifier.JwtData memory jwtData = EmailGuardianVerifier
+            .JwtData({
+                domainName: jwtProof.domainName,
+                timestamp: jwtProof.timestamp,
+                maskedCommand: jwtProof.maskedCommand,
+                accountSalt: accountSalt,
+                isCodeExist: jwtProof.isCodeExist,
+                isRecovery: false // Acceptance
+            });
+
+        bytes32[] memory acceptancePublicInputs = new bytes32[](2);
+        acceptancePublicInputs[0] = emailProof.publicKeyHash; // publicKeyHash
+        acceptancePublicInputs[1] = emailProof.emailNullifier; // emailNullifier
+
+        proofData = IGuardianVerifier.ProofData({
+            proof: emailProof.proof,
+            publicInputs: acceptancePublicInputs,
+            data: abi.encode(jwtData)
+        });
+    }
+}

--- a/test-new/JwtGuardianVerifier/JwtGuardianVerifierBase.t.sol
+++ b/test-new/JwtGuardianVerifier/JwtGuardianVerifierBase.t.sol
@@ -188,7 +188,6 @@ abstract contract OwnableValidatorRecovery_AbstractedRecoveryModule_Base is
 
     // Helper functions
     function deployModule() public override {
-        // Deploy the email recovery factory after removing email guardian verifier related logic
         emailRecoveryFactory = new EmailRecoveryFactory();
 
         bytes32 recoveryModuleSalt = bytes32(uint256(0));
@@ -284,12 +283,12 @@ abstract contract OwnableValidatorRecovery_AbstractedRecoveryModule_Base is
                 maskedCommand: jwtProof.maskedCommand,
                 accountSalt: accountSalt,
                 isCodeExist: jwtProof.isCodeExist,
-                isRecovery: false // Acceptance
+                isRecovery: false
             });
 
         bytes32[] memory acceptancePublicInputs = new bytes32[](2);
-        acceptancePublicInputs[0] = jwtProof.publicKeyHash; // publicKeyHash
-        acceptancePublicInputs[1] = jwtProof.emailNullifier; // emailNullifier
+        acceptancePublicInputs[0] = jwtProof.publicKeyHash;
+        acceptancePublicInputs[1] = jwtProof.emailNullifier;
 
         proofData = IGuardianVerifier.ProofData({
             proof: jwtProof.proof,
@@ -348,12 +347,12 @@ abstract contract OwnableValidatorRecovery_AbstractedRecoveryModule_Base is
                 maskedCommand: jwtProof.maskedCommand,
                 accountSalt: accountSalt,
                 isCodeExist: jwtProof.isCodeExist,
-                isRecovery: false // Acceptance
+                isRecovery: true
             });
 
         bytes32[] memory acceptancePublicInputs = new bytes32[](2);
-        acceptancePublicInputs[0] = jwtProof.publicKeyHash; // publicKeyHash
-        acceptancePublicInputs[1] = jwtProof.emailNullifier; // emailNullifier
+        acceptancePublicInputs[0] = jwtProof.publicKeyHash;
+        acceptancePublicInputs[1] = jwtProof.emailNullifier;
 
         proofData = IGuardianVerifier.ProofData({
             proof: jwtProof.proof,


### PR DESCRIPTION
## Introduction
Using jwt as a verification method for guardians was not possible

## Solution
The Jwt guardian is now added as JwtGuardianVerifier.sol module that implements of the IGuardianVerifier .

Verification logic is basic JWT verification which was taken as reference from [JwtVerifier.sol](https://github.com/zkemail/jwt-tx-builder/blob/main/packages/contracts/src/utils/JwtVerifier.sol)

## Notes
- Currently only the Jwt groth16 proof is being verified in the verification logic, needs to be updated on what else to verify. 
- Specific claims are not verified here for acceptance & recovery
- JwtRegistry verification is unclear and not implemented, to be discussed